### PR TITLE
Reverse Z Projection matrix to Infinity

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -503,6 +503,7 @@ HMMDEF hmm_mat4 HMM_Transpose(hmm_mat4 Matrix);
 
 HMMDEF hmm_mat4 HMM_Orthographic(float Left, float Right, float Bottom, float Top, float Near, float Far);
 HMMDEF hmm_mat4 HMM_Perspective(float FOV, float AspectRatio, float Near, float Far);
+HMMDEF hmm_mat4 HMM_PerspectiveReverseZToInfinity(float FOV, float AspectRatio, float Near)
 
 HMMDEF hmm_mat4 HMM_Translate(hmm_vec3 Translation);
 HMMDEF hmm_mat4 HMM_Rotate(float Angle, hmm_vec3 Axis);
@@ -1515,10 +1516,10 @@ HMM_Scale(hmm_vec3 Scale)
 }
 
 HINLINE hmm_mat4
-HMM_ReverseZPerspectiveToInfinity(float FOV_Degrees, float AspectRatio, float Near){
+HMM_PerspectiveReverseZToInfinity(float FOV, float AspectRatio, float Near){
     hmm_mat4 Result = HMM_Mat4();
     
-    float f = 1.f / HMM_TanF(HMM_ToRadians(FOV_Degrees) / 2.f);
+    float f = 1.f / HMM_TanF(HMM_ToRadians(FOV) / 2.f);
 
     Result.Elements[0][0] = f / AspectRatio;
     Result.Elements[1][1] = f;

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -503,7 +503,7 @@ HMMDEF hmm_mat4 HMM_Transpose(hmm_mat4 Matrix);
 
 HMMDEF hmm_mat4 HMM_Orthographic(float Left, float Right, float Bottom, float Top, float Near, float Far);
 HMMDEF hmm_mat4 HMM_Perspective(float FOV, float AspectRatio, float Near, float Far);
-HMMDEF hmm_mat4 HMM_PerspectiveReverseZToInfinity(float FOV, float AspectRatio, float Near)
+HMMDEF hmm_mat4 HMM_PerspectiveReverseZToInfinity(float FOV, float AspectRatio, float Near);
 
 HMMDEF hmm_mat4 HMM_Translate(hmm_vec3 Translation);
 HMMDEF hmm_mat4 HMM_Rotate(float Angle, hmm_vec3 Axis);

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -1515,6 +1515,20 @@ HMM_Scale(hmm_vec3 Scale)
 }
 
 HINLINE hmm_mat4
+HMM_ReverseZPerspectiveToInfinity(float FOV_Degrees, float AspectRatio, float Near){
+    hmm_mat4 Result = HMM_Mat4();
+    
+    float f = 1.f / HMM_TanF(HMM_ToRadians(FOV_Degrees) / 2.f);
+
+    Result.Elements[0][0] = f / AspectRatio;
+    Result.Elements[1][1] = f;
+    Result.Elements[2][3] = -1.f;
+    Result.Elements[3][2] = Near;
+    
+    return Result;
+}
+
+HINLINE hmm_mat4
 HMM_LookAt(hmm_vec3 Eye, hmm_vec3 Center, hmm_vec3 Up)
 {
     hmm_mat4 Result = {0};

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -1517,16 +1517,16 @@ HMM_Scale(hmm_vec3 Scale)
 
 HINLINE hmm_mat4
 HMM_PerspectiveReverseZToInfinity(float FOV, float AspectRatio, float Near){
-    hmm_mat4 Result = HMM_Mat4();
+    hmm_mat4 Result = {0};
     
-    float f = 1.f / HMM_TanF(HMM_ToRadians(FOV) / 2.f);
+    float f = 1.f / HMM_TanF(HMM_ToRadians(FOV) / 2.0f);
 
     Result.Elements[0][0] = f / AspectRatio;
     Result.Elements[1][1] = f;
-    Result.Elements[2][3] = -1.f;
+    Result.Elements[2][3] = -1.0f;
     Result.Elements[3][2] = Near;
     
-    return Result;
+    return (Result);
 }
 
 HINLINE hmm_mat4

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -1516,10 +1516,11 @@ HMM_Scale(hmm_vec3 Scale)
 }
 
 HINLINE hmm_mat4
-HMM_PerspectiveReverseZToInfinity(float FOV, float AspectRatio, float Near){
+HMM_PerspectiveReverseZToInfinity(float FOV, float AspectRatio, float Near)
+{
     hmm_mat4 Result = {0};
     
-    float f = 1.f / HMM_TanF(HMM_ToRadians(FOV) / 2.0f);
+    float f = 1.0f / HMM_TanF(HMM_ToRadians(FOV) / 2.0f);
 
     Result.Elements[0][0] = f / AspectRatio;
     Result.Elements[1][1] = f;


### PR DESCRIPTION
I needed this for my game, and thought, since this is a math library for games, I would share.

Reverse Z is common place now in OpenGL to improve depth precision. I made use of that by extending the far plane into infinity. This function conveniently does both.