### PR TITLE
Convert everything to new inline scheme (#57)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+# Understanding the structure of Handmade Math
+
+Most of the functions in Handmade Math are very short, and are the kind of functions you want to have inlined. Because of this, most functions in Handmade Math are defined with `HINLINE`, which is defined as `static inline`.
+
+The exceptions are functions like `HMM_Rotate`, which are long enough that it doesn't make sense to inline them. These functions are defined with an `HEXTERN` prototype, and implemented in the `#ifdef HANDMADE_MATH_IMPLEMENTATION` block.
+
 # Quick style guide
 
 * Put braces on a new line
@@ -12,23 +18,6 @@
   // Bad
   1.f
   .0f
-  ```
-* Put macros and return types on a separate line from the function definition:
-  ```cpp
-  HINLINE float
-  HMM_MyFunction()
-  {
-      // ...
-  }
-  ```
-* Explicitly initialize variables to zero:
-  ```cpp
-  HINLINE float
-  HMM_MyFunction()
-  {
-      float MyFloat = 0.0f;
-      hmm_vec3 MyVector = {0};
-  }
   ```
 * Put parentheses around the returned value:
   ```cpp

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -235,8 +235,8 @@ extern "C"
 {
 #endif
 
-#define HINLINE static inline
-#define HEXTERN extern
+#define HMM_INLINE static inline
+#define HMM_EXTERN extern
 
 #if !defined(HMM_SINF) || !defined(HMM_COSF) || !defined(HMM_TANF) || \
     !defined(HMM_SQRTF) || !defined(HMM_EXPF) || !defined(HMM_LOGF) || \
@@ -455,63 +455,63 @@ typedef hmm_mat4 hmm_m4;
  * Floating-point math functions
  */
 
-HINLINE float HMM_SinF(float Radians)
+HMM_INLINE float HMM_SinF(float Radians)
 {
     float Result = HMM_SINF(Radians);
     
     return (Result);
 }
 
-HINLINE float HMM_CosF(float Radians)
+HMM_INLINE float HMM_CosF(float Radians)
 {
     float Result = HMM_COSF(Radians);
     
     return (Result);
 }
 
-HINLINE float HMM_TanF(float Radians)
+HMM_INLINE float HMM_TanF(float Radians)
 {
     float Result = HMM_TANF(Radians);
     
     return (Result);
 }
 
-HINLINE float HMM_ACosF(float Radians)
+HMM_INLINE float HMM_ACosF(float Radians)
 {
     float Result = HMM_ACOSF(Radians);
     
     return (Result);
 }
 
-HINLINE float HMM_ATanF(float Radians)
+HMM_INLINE float HMM_ATanF(float Radians)
 {
     float Result = HMM_ATANF(Radians);
     
     return (Result);
 }
 
-HINLINE float HMM_ATan2F(float Left, float Right)
+HMM_INLINE float HMM_ATan2F(float Left, float Right)
 {
     float Result = HMM_ATAN2F(Left, Right);
     
     return (Result);
 }
 
-HINLINE float HMM_ExpF(float Float)
+HMM_INLINE float HMM_ExpF(float Float)
 {
     float Result = HMM_EXPF(Float);
     
     return (Result);
 }
 
-HINLINE float HMM_LogF(float Float)
+HMM_INLINE float HMM_LogF(float Float)
 {
     float Result = HMM_LOGF(Float);
     
     return (Result);
 }
 
-HINLINE float HMM_SquareRootF(float Float)
+HMM_INLINE float HMM_SquareRootF(float Float)
 {
     float Result;
 
@@ -526,7 +526,7 @@ HINLINE float HMM_SquareRootF(float Float)
     return(Result);
 }
 
-HINLINE float HMM_RSquareRootF(float Float)
+HMM_INLINE float HMM_RSquareRootF(float Float)
 {
     float Result;
 
@@ -541,9 +541,9 @@ HINLINE float HMM_RSquareRootF(float Float)
     return(Result);
 }
 
-HEXTERN float HMM_Power(float Base, int Exponent);
+HMM_EXTERN float HMM_Power(float Base, int Exponent);
 
-HINLINE float HMM_PowerF(float Base, float Exponent)
+HMM_INLINE float HMM_PowerF(float Base, float Exponent)
 {
     float Result = HMM_EXPF(Exponent * HMM_LOGF(Base));
 
@@ -554,21 +554,21 @@ HINLINE float HMM_PowerF(float Base, float Exponent)
 /*
  * Utility functions
  */
-HINLINE float HMM_ToRadians(float Degrees)
+HMM_INLINE float HMM_ToRadians(float Degrees)
 {
     float Result = Degrees * (HMM_PI32 / 180.0f);
     
     return (Result);
 }
 
-HINLINE float HMM_Lerp(float A, float Time, float B)
+HMM_INLINE float HMM_Lerp(float A, float Time, float B)
 {
     float Result = (1.0f - Time) * A + Time * B;
 
     return (Result);
 }
 
-HINLINE float HMM_Clamp(float Min, float Value, float Max)
+HMM_INLINE float HMM_Clamp(float Min, float Value, float Max)
 {
     float Result = Value;
 
@@ -589,7 +589,7 @@ HINLINE float HMM_Clamp(float Min, float Value, float Max)
  * Vector initialization
  */
 
-HINLINE hmm_vec2 HMM_Vec2(float X, float Y)
+HMM_INLINE hmm_vec2 HMM_Vec2(float X, float Y)
 {
     hmm_vec2 Result;
 
@@ -599,7 +599,7 @@ HINLINE hmm_vec2 HMM_Vec2(float X, float Y)
     return (Result);
 }
 
-HINLINE hmm_vec2 HMM_Vec2i(int X, int Y)
+HMM_INLINE hmm_vec2 HMM_Vec2i(int X, int Y)
 {
     hmm_vec2 Result;
 
@@ -609,7 +609,7 @@ HINLINE hmm_vec2 HMM_Vec2i(int X, int Y)
     return (Result);
 }
 
-HINLINE hmm_vec3 HMM_Vec3(float X, float Y, float Z)
+HMM_INLINE hmm_vec3 HMM_Vec3(float X, float Y, float Z)
 {
     hmm_vec3 Result;
 
@@ -620,7 +620,7 @@ HINLINE hmm_vec3 HMM_Vec3(float X, float Y, float Z)
     return (Result);
 }
 
-HINLINE hmm_vec3 HMM_Vec3i(int X, int Y, int Z)
+HMM_INLINE hmm_vec3 HMM_Vec3i(int X, int Y, int Z)
 {
     hmm_vec3 Result;
 
@@ -631,7 +631,7 @@ HINLINE hmm_vec3 HMM_Vec3i(int X, int Y, int Z)
     return (Result);
 }
 
-HINLINE hmm_vec4 HMM_Vec4(float X, float Y, float Z, float W)
+HMM_INLINE hmm_vec4 HMM_Vec4(float X, float Y, float Z, float W)
 {
     hmm_vec4 Result;
 
@@ -647,7 +647,7 @@ HINLINE hmm_vec4 HMM_Vec4(float X, float Y, float Z, float W)
     return (Result);
 }
 
-HINLINE hmm_vec4 HMM_Vec4i(int X, int Y, int Z, int W)
+HMM_INLINE hmm_vec4 HMM_Vec4i(int X, int Y, int Z, int W)
 {
     hmm_vec4 Result;
 
@@ -663,7 +663,7 @@ HINLINE hmm_vec4 HMM_Vec4i(int X, int Y, int Z, int W)
     return (Result);
 }
 
-HINLINE hmm_vec4 HMM_Vec4v(hmm_vec3 Vector, float W)
+HMM_INLINE hmm_vec4 HMM_Vec4v(hmm_vec3 Vector, float W)
 {
     hmm_vec4 Result;
     
@@ -682,7 +682,7 @@ HINLINE hmm_vec4 HMM_Vec4v(hmm_vec3 Vector, float W)
  * Binary vector operations
  */
 
-HINLINE hmm_vec2 HMM_AddVec2(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 HMM_AddVec2(hmm_vec2 Left, hmm_vec2 Right)
 {
     hmm_vec2 Result;
 
@@ -692,7 +692,7 @@ HINLINE hmm_vec2 HMM_AddVec2(hmm_vec2 Left, hmm_vec2 Right)
     return (Result);
 }
 
-HINLINE hmm_vec3 HMM_AddVec3(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 HMM_AddVec3(hmm_vec3 Left, hmm_vec3 Right)
 {
     hmm_vec3 Result;
 
@@ -703,7 +703,7 @@ HINLINE hmm_vec3 HMM_AddVec3(hmm_vec3 Left, hmm_vec3 Right)
     return (Result);
 }
 
-HINLINE hmm_vec4 HMM_AddVec4(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 HMM_AddVec4(hmm_vec4 Left, hmm_vec4 Right)
 {
     hmm_vec4 Result;
 
@@ -719,7 +719,7 @@ HINLINE hmm_vec4 HMM_AddVec4(hmm_vec4 Left, hmm_vec4 Right)
     return (Result);
 }
 
-HINLINE hmm_vec2 HMM_SubtractVec2(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 HMM_SubtractVec2(hmm_vec2 Left, hmm_vec2 Right)
 {
     hmm_vec2 Result;
 
@@ -729,7 +729,7 @@ HINLINE hmm_vec2 HMM_SubtractVec2(hmm_vec2 Left, hmm_vec2 Right)
     return (Result);
 }
 
-HINLINE hmm_vec3 HMM_SubtractVec3(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 HMM_SubtractVec3(hmm_vec3 Left, hmm_vec3 Right)
 {
     hmm_vec3 Result;
 
@@ -740,7 +740,7 @@ HINLINE hmm_vec3 HMM_SubtractVec3(hmm_vec3 Left, hmm_vec3 Right)
     return (Result);
 }
 
-HINLINE hmm_vec4 HMM_SubtractVec4(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 HMM_SubtractVec4(hmm_vec4 Left, hmm_vec4 Right)
 {
     hmm_vec4 Result;
     
@@ -756,7 +756,7 @@ HINLINE hmm_vec4 HMM_SubtractVec4(hmm_vec4 Left, hmm_vec4 Right)
     return (Result);
 }
 
-HINLINE hmm_vec2 HMM_MultiplyVec2(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 HMM_MultiplyVec2(hmm_vec2 Left, hmm_vec2 Right)
 {
     hmm_vec2 Result;
 
@@ -766,7 +766,7 @@ HINLINE hmm_vec2 HMM_MultiplyVec2(hmm_vec2 Left, hmm_vec2 Right)
     return (Result);
 }
 
-HINLINE hmm_vec2 HMM_MultiplyVec2f(hmm_vec2 Left, float Right)
+HMM_INLINE hmm_vec2 HMM_MultiplyVec2f(hmm_vec2 Left, float Right)
 {
     hmm_vec2 Result;
 
@@ -776,7 +776,7 @@ HINLINE hmm_vec2 HMM_MultiplyVec2f(hmm_vec2 Left, float Right)
     return (Result);
 }
 
-HINLINE hmm_vec3 HMM_MultiplyVec3(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 HMM_MultiplyVec3(hmm_vec3 Left, hmm_vec3 Right)
 {
     hmm_vec3 Result;
 
@@ -787,7 +787,7 @@ HINLINE hmm_vec3 HMM_MultiplyVec3(hmm_vec3 Left, hmm_vec3 Right)
     return (Result);
 }
 
-HINLINE hmm_vec3 HMM_MultiplyVec3f(hmm_vec3 Left, float Right)
+HMM_INLINE hmm_vec3 HMM_MultiplyVec3f(hmm_vec3 Left, float Right)
 {
     hmm_vec3 Result;
 
@@ -798,7 +798,7 @@ HINLINE hmm_vec3 HMM_MultiplyVec3f(hmm_vec3 Left, float Right)
     return (Result);
 }
 
-HINLINE hmm_vec4 HMM_MultiplyVec4(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 HMM_MultiplyVec4(hmm_vec4 Left, hmm_vec4 Right)
 {
     hmm_vec4 Result;
 
@@ -814,7 +814,7 @@ HINLINE hmm_vec4 HMM_MultiplyVec4(hmm_vec4 Left, hmm_vec4 Right)
     return (Result);
 }
 
-HINLINE hmm_vec4 HMM_MultiplyVec4f(hmm_vec4 Left, float Right)
+HMM_INLINE hmm_vec4 HMM_MultiplyVec4f(hmm_vec4 Left, float Right)
 {
     hmm_vec4 Result;
 
@@ -831,7 +831,7 @@ HINLINE hmm_vec4 HMM_MultiplyVec4f(hmm_vec4 Left, float Right)
     return (Result);
 }
 
-HINLINE hmm_vec2 HMM_DivideVec2(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 HMM_DivideVec2(hmm_vec2 Left, hmm_vec2 Right)
 {
     hmm_vec2 Result;
 
@@ -841,7 +841,7 @@ HINLINE hmm_vec2 HMM_DivideVec2(hmm_vec2 Left, hmm_vec2 Right)
     return (Result);
 }
 
-HINLINE hmm_vec2 HMM_DivideVec2f(hmm_vec2 Left, float Right)
+HMM_INLINE hmm_vec2 HMM_DivideVec2f(hmm_vec2 Left, float Right)
 {
     hmm_vec2 Result;
 
@@ -851,7 +851,7 @@ HINLINE hmm_vec2 HMM_DivideVec2f(hmm_vec2 Left, float Right)
     return (Result);
 }
 
-HINLINE hmm_vec3 HMM_DivideVec3(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 HMM_DivideVec3(hmm_vec3 Left, hmm_vec3 Right)
 {
     hmm_vec3 Result;
 
@@ -862,7 +862,7 @@ HINLINE hmm_vec3 HMM_DivideVec3(hmm_vec3 Left, hmm_vec3 Right)
     return (Result);
 }
 
-HINLINE hmm_vec3 HMM_DivideVec3f(hmm_vec3 Left, float Right)
+HMM_INLINE hmm_vec3 HMM_DivideVec3f(hmm_vec3 Left, float Right)
 {
     hmm_vec3 Result;
 
@@ -873,7 +873,7 @@ HINLINE hmm_vec3 HMM_DivideVec3f(hmm_vec3 Left, float Right)
     return (Result);
 }
 
-HINLINE hmm_vec4 HMM_DivideVec4(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 HMM_DivideVec4(hmm_vec4 Left, hmm_vec4 Right)
 {
     hmm_vec4 Result;
     
@@ -889,7 +889,7 @@ HINLINE hmm_vec4 HMM_DivideVec4(hmm_vec4 Left, hmm_vec4 Right)
     return (Result);
 }
 
-HINLINE hmm_vec4 HMM_DivideVec4f(hmm_vec4 Left, float Right)
+HMM_INLINE hmm_vec4 HMM_DivideVec4f(hmm_vec4 Left, float Right)
 {
     hmm_vec4 Result;
 
@@ -906,42 +906,42 @@ HINLINE hmm_vec4 HMM_DivideVec4f(hmm_vec4 Left, float Right)
     return (Result);
 }
 
-HINLINE hmm_bool HMM_EqualsVec2(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_bool HMM_EqualsVec2(hmm_vec2 Left, hmm_vec2 Right)
 {
     hmm_bool Result = (Left.X == Right.X && Left.Y == Right.Y);
 
     return (Result);
 }
 
-HINLINE hmm_bool HMM_EqualsVec3(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_bool HMM_EqualsVec3(hmm_vec3 Left, hmm_vec3 Right)
 {
     hmm_bool Result = (Left.X == Right.X && Left.Y == Right.Y && Left.Z == Right.Z);
 
     return (Result);
 }
 
-HINLINE hmm_bool HMM_EqualsVec4(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_bool HMM_EqualsVec4(hmm_vec4 Left, hmm_vec4 Right)
 {
     hmm_bool Result = (Left.X == Right.X && Left.Y == Right.Y && Left.Z == Right.Z && Left.W == Right.W);
 
     return (Result);
 }
 
-HINLINE float HMM_DotVec2(hmm_vec2 VecOne, hmm_vec2 VecTwo)
+HMM_INLINE float HMM_DotVec2(hmm_vec2 VecOne, hmm_vec2 VecTwo)
 {
     float Result = (VecOne.X * VecTwo.X) + (VecOne.Y * VecTwo.Y);
     
     return (Result);
 }
 
-HINLINE float HMM_DotVec3(hmm_vec3 VecOne, hmm_vec3 VecTwo)
+HMM_INLINE float HMM_DotVec3(hmm_vec3 VecOne, hmm_vec3 VecTwo)
 {
     float Result = (VecOne.X * VecTwo.X) + (VecOne.Y * VecTwo.Y) + (VecOne.Z * VecTwo.Z);
     
     return (Result);
 }
 
-HINLINE float HMM_DotVec4(hmm_vec4 VecOne, hmm_vec4 VecTwo)
+HMM_INLINE float HMM_DotVec4(hmm_vec4 VecOne, hmm_vec4 VecTwo)
 {
     float Result;
 
@@ -962,7 +962,7 @@ HINLINE float HMM_DotVec4(hmm_vec4 VecOne, hmm_vec4 VecTwo)
     return (Result);
 }
 
-HINLINE hmm_vec3 HMM_Cross(hmm_vec3 VecOne, hmm_vec3 VecTwo)
+HMM_INLINE hmm_vec3 HMM_Cross(hmm_vec3 VecOne, hmm_vec3 VecTwo)
 {
     hmm_vec3 Result;
 
@@ -978,49 +978,49 @@ HINLINE hmm_vec3 HMM_Cross(hmm_vec3 VecOne, hmm_vec3 VecTwo)
  * Unary vector operations
  */
 
-HINLINE float HMM_LengthSquaredVec2(hmm_vec2 A)
+HMM_INLINE float HMM_LengthSquaredVec2(hmm_vec2 A)
 {
     float Result = HMM_DotVec2(A, A);
     
     return(Result);
 }
 
-HINLINE float HMM_LengthSquaredVec3(hmm_vec3 A)
+HMM_INLINE float HMM_LengthSquaredVec3(hmm_vec3 A)
 {
     float Result = HMM_DotVec3(A, A);
     
     return (Result);
 }
 
-HINLINE float HMM_LengthSquaredVec4(hmm_vec4 A)
+HMM_INLINE float HMM_LengthSquaredVec4(hmm_vec4 A)
 {
     float Result = HMM_DotVec4(A, A);
     
     return (Result);
 }
 
-HINLINE float HMM_LengthVec2(hmm_vec2 A)
+HMM_INLINE float HMM_LengthVec2(hmm_vec2 A)
 {
     float Result = HMM_SquareRootF(HMM_LengthSquaredVec2(A));
     
     return (Result);
 }
 
-HINLINE float HMM_LengthVec3(hmm_vec3 A)
+HMM_INLINE float HMM_LengthVec3(hmm_vec3 A)
 {
     float Result = HMM_SquareRootF(HMM_LengthSquaredVec3(A));
     
     return (Result);
 }
 
-HINLINE float HMM_LengthVec4(hmm_vec4 A)
+HMM_INLINE float HMM_LengthVec4(hmm_vec4 A)
 {
     float Result = HMM_SquareRootF(HMM_LengthSquaredVec4(A));
     
     return(Result);
 }
 
-HINLINE hmm_vec2 HMM_NormalizeVec2(hmm_vec2 A)
+HMM_INLINE hmm_vec2 HMM_NormalizeVec2(hmm_vec2 A)
 {
     hmm_vec2 Result = {0};
 
@@ -1036,7 +1036,7 @@ HINLINE hmm_vec2 HMM_NormalizeVec2(hmm_vec2 A)
     return (Result);
 }
 
-HINLINE hmm_vec3 HMM_NormalizeVec3(hmm_vec3 A)
+HMM_INLINE hmm_vec3 HMM_NormalizeVec3(hmm_vec3 A)
 {
     hmm_vec3 Result = {0};
 
@@ -1053,7 +1053,7 @@ HINLINE hmm_vec3 HMM_NormalizeVec3(hmm_vec3 A)
     return (Result);
 }
 
-HINLINE hmm_vec4 HMM_NormalizeVec4(hmm_vec4 A)
+HMM_INLINE hmm_vec4 HMM_NormalizeVec4(hmm_vec4 A)
 {
     hmm_vec4 Result = {0};
 
@@ -1084,7 +1084,7 @@ HINLINE hmm_vec4 HMM_NormalizeVec4(hmm_vec4 A)
  */
 
 #ifdef HANDMADE_MATH__USE_SSE
-HINLINE __m128 HMM_LinearCombineSSE(__m128 Left, hmm_mat4 Right)
+HMM_INLINE __m128 HMM_LinearCombineSSE(__m128 Left, hmm_mat4 Right)
 {
     __m128 Result;
     Result = _mm_mul_ps(_mm_shuffle_ps(Left, Left, 0x00), Right.Rows[0]);
@@ -1101,14 +1101,14 @@ HINLINE __m128 HMM_LinearCombineSSE(__m128 Left, hmm_mat4 Right)
  * Matrix functions
  */
 
-HINLINE hmm_mat4 HMM_Mat4(void)
+HMM_INLINE hmm_mat4 HMM_Mat4(void)
 {
     hmm_mat4 Result = {0};
 
     return (Result);
 }
 
-HINLINE hmm_mat4 HMM_Mat4d(float Diagonal)
+HMM_INLINE hmm_mat4 HMM_Mat4d(float Diagonal)
 {
     hmm_mat4 Result = HMM_Mat4();
     
@@ -1121,7 +1121,7 @@ HINLINE hmm_mat4 HMM_Mat4d(float Diagonal)
 }
 
 #ifdef HANDMADE_MATH__USE_SSE
-HINLINE hmm_mat4 HMM_Transpose(hmm_mat4 Matrix)
+HMM_INLINE hmm_mat4 HMM_Transpose(hmm_mat4 Matrix)
 {
     hmm_mat4 Result = Matrix;
     
@@ -1130,11 +1130,11 @@ HINLINE hmm_mat4 HMM_Transpose(hmm_mat4 Matrix)
     return (Result);
 }
 #else
-HEXTERN hmm_mat4 HMM_Transpose(hmm_mat4 Matrix);
+HMM_EXTERN hmm_mat4 HMM_Transpose(hmm_mat4 Matrix);
 #endif
 
 #ifdef HANDMADE_MATH__USE_SSE
-HINLINE hmm_mat4 HMM_AddMat4(hmm_mat4 Left, hmm_mat4 Right)
+HMM_INLINE hmm_mat4 HMM_AddMat4(hmm_mat4 Left, hmm_mat4 Right)
 {
     hmm_mat4 Result;
 
@@ -1146,11 +1146,11 @@ HINLINE hmm_mat4 HMM_AddMat4(hmm_mat4 Left, hmm_mat4 Right)
     return (Result);
 }
 #else
-HEXTERN hmm_mat4 HMM_AddMat4(hmm_mat4 Left, hmm_mat4 Right);
+HMM_EXTERN hmm_mat4 HMM_AddMat4(hmm_mat4 Left, hmm_mat4 Right);
 #endif
 
 #ifdef HANDMADE_MATH__USE_SSE
-HINLINE hmm_mat4 HMM_SubtractMat4(hmm_mat4 Left, hmm_mat4 Right)
+HMM_INLINE hmm_mat4 HMM_SubtractMat4(hmm_mat4 Left, hmm_mat4 Right)
 {
     hmm_mat4 Result;
 
@@ -1162,13 +1162,13 @@ HINLINE hmm_mat4 HMM_SubtractMat4(hmm_mat4 Left, hmm_mat4 Right)
     return (Result);
 }
 #else
-HEXTERN hmm_mat4 HMM_SubtractMat4(hmm_mat4 Left, hmm_mat4 Right);
+HMM_EXTERN hmm_mat4 HMM_SubtractMat4(hmm_mat4 Left, hmm_mat4 Right);
 #endif
 
-HEXTERN hmm_mat4 HMM_MultiplyMat4(hmm_mat4 Left, hmm_mat4 Right);
+HMM_EXTERN hmm_mat4 HMM_MultiplyMat4(hmm_mat4 Left, hmm_mat4 Right);
 
 #ifdef HANDMADE_MATH__USE_SSE
-HINLINE hmm_mat4 HMM_MultiplyMat4f(hmm_mat4 Matrix, float Scalar)
+HMM_INLINE hmm_mat4 HMM_MultiplyMat4f(hmm_mat4 Matrix, float Scalar)
 {
     hmm_mat4 Result;
 
@@ -1181,13 +1181,13 @@ HINLINE hmm_mat4 HMM_MultiplyMat4f(hmm_mat4 Matrix, float Scalar)
     return (Result);
 }
 #else
-HEXTERN hmm_mat4 HMM_MultiplyMat4f(hmm_mat4 Matrix, float Scalar);
+HMM_EXTERN hmm_mat4 HMM_MultiplyMat4f(hmm_mat4 Matrix, float Scalar);
 #endif
 
-HEXTERN hmm_vec4 HMM_MultiplyMat4ByVec4(hmm_mat4 Matrix, hmm_vec4 Vector);
+HMM_EXTERN hmm_vec4 HMM_MultiplyMat4ByVec4(hmm_mat4 Matrix, hmm_vec4 Vector);
 
 #ifdef HANDMADE_MATH__USE_SSE
-HINLINE hmm_mat4 HMM_DivideMat4f(hmm_mat4 Matrix, float Scalar)
+HMM_INLINE hmm_mat4 HMM_DivideMat4f(hmm_mat4 Matrix, float Scalar)
 {
     hmm_mat4 Result;
     
@@ -1200,7 +1200,7 @@ HINLINE hmm_mat4 HMM_DivideMat4f(hmm_mat4 Matrix, float Scalar)
     return (Result);
 }
 #else
-HEXTERN hmm_mat4 HMM_DivideMat4f(hmm_mat4 Matrix, float Scalar);
+HMM_EXTERN hmm_mat4 HMM_DivideMat4f(hmm_mat4 Matrix, float Scalar);
 #endif
 
 
@@ -1208,7 +1208,7 @@ HEXTERN hmm_mat4 HMM_DivideMat4f(hmm_mat4 Matrix, float Scalar);
  * Common graphics transformations
  */
 
-HINLINE hmm_mat4 HMM_Orthographic(float Left, float Right, float Bottom, float Top, float Near, float Far)
+HMM_INLINE hmm_mat4 HMM_Orthographic(float Left, float Right, float Bottom, float Top, float Near, float Far)
 {
     hmm_mat4 Result = HMM_Mat4();
 
@@ -1224,7 +1224,7 @@ HINLINE hmm_mat4 HMM_Orthographic(float Left, float Right, float Bottom, float T
     return (Result);
 }
 
-HINLINE hmm_mat4 HMM_Perspective(float FOV, float AspectRatio, float Near, float Far)
+HMM_INLINE hmm_mat4 HMM_Perspective(float FOV, float AspectRatio, float Near, float Far)
 {
     hmm_mat4 Result = HMM_Mat4();
 
@@ -1240,7 +1240,7 @@ HINLINE hmm_mat4 HMM_Perspective(float FOV, float AspectRatio, float Near, float
     return (Result);
 }
 
-HINLINE hmm_mat4 HMM_Translate(hmm_vec3 Translation)
+HMM_INLINE hmm_mat4 HMM_Translate(hmm_vec3 Translation)
 {
     hmm_mat4 Result = HMM_Mat4d(1.0f);
 
@@ -1251,9 +1251,9 @@ HINLINE hmm_mat4 HMM_Translate(hmm_vec3 Translation)
     return (Result);
 }
 
-HEXTERN hmm_mat4 HMM_Rotate(float Angle, hmm_vec3 Axis);
+HMM_EXTERN hmm_mat4 HMM_Rotate(float Angle, hmm_vec3 Axis);
 
-HINLINE hmm_mat4 HMM_Scale(hmm_vec3 Scale)
+HMM_INLINE hmm_mat4 HMM_Scale(hmm_vec3 Scale)
 {
     hmm_mat4 Result = HMM_Mat4d(1.0f);
 
@@ -1264,14 +1264,14 @@ HINLINE hmm_mat4 HMM_Scale(hmm_vec3 Scale)
     return (Result);
 }
 
-HEXTERN hmm_mat4 HMM_LookAt(hmm_vec3 Eye, hmm_vec3 Center, hmm_vec3 Up);
+HMM_EXTERN hmm_mat4 HMM_LookAt(hmm_vec3 Eye, hmm_vec3 Center, hmm_vec3 Up);
 
 
 /*
  * Quaternion operations
  */
 
-HINLINE hmm_quaternion HMM_Quaternion(float X, float Y, float Z, float W)
+HMM_INLINE hmm_quaternion HMM_Quaternion(float X, float Y, float Z, float W)
 {
     hmm_quaternion Result;
 
@@ -1283,7 +1283,7 @@ HINLINE hmm_quaternion HMM_Quaternion(float X, float Y, float Z, float W)
     return (Result);
 }
 
-HINLINE hmm_quaternion HMM_QuaternionV4(hmm_vec4 Vector)
+HMM_INLINE hmm_quaternion HMM_QuaternionV4(hmm_vec4 Vector)
 {
     hmm_quaternion Result;
 
@@ -1295,7 +1295,7 @@ HINLINE hmm_quaternion HMM_QuaternionV4(hmm_vec4 Vector)
     return (Result);
 }
 
-HINLINE hmm_quaternion HMM_AddQuaternion(hmm_quaternion Left, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion HMM_AddQuaternion(hmm_quaternion Left, hmm_quaternion Right)
 {
     hmm_quaternion Result;
 
@@ -1307,7 +1307,7 @@ HINLINE hmm_quaternion HMM_AddQuaternion(hmm_quaternion Left, hmm_quaternion Rig
     return (Result);
 }
 
-HINLINE hmm_quaternion HMM_SubtractQuaternion(hmm_quaternion Left, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion HMM_SubtractQuaternion(hmm_quaternion Left, hmm_quaternion Right)
 {
     hmm_quaternion Result;
 
@@ -1319,7 +1319,7 @@ HINLINE hmm_quaternion HMM_SubtractQuaternion(hmm_quaternion Left, hmm_quaternio
     return (Result);
 }
 
-HINLINE hmm_quaternion HMM_MultiplyQuaternion(hmm_quaternion Left, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion HMM_MultiplyQuaternion(hmm_quaternion Left, hmm_quaternion Right)
 {
     hmm_quaternion Result;
 
@@ -1331,7 +1331,7 @@ HINLINE hmm_quaternion HMM_MultiplyQuaternion(hmm_quaternion Left, hmm_quaternio
     return (Result);
 }
 
-HINLINE hmm_quaternion HMM_MultiplyQuaternionF(hmm_quaternion Left, float Multiplicative)
+HMM_INLINE hmm_quaternion HMM_MultiplyQuaternionF(hmm_quaternion Left, float Multiplicative)
 {
     hmm_quaternion Result;
 
@@ -1343,7 +1343,7 @@ HINLINE hmm_quaternion HMM_MultiplyQuaternionF(hmm_quaternion Left, float Multip
     return (Result);
 }
 
-HINLINE hmm_quaternion HMM_DivideQuaternionF(hmm_quaternion Left, float Dividend)
+HMM_INLINE hmm_quaternion HMM_DivideQuaternionF(hmm_quaternion Left, float Dividend)
 {
     hmm_quaternion Result;
 
@@ -1355,16 +1355,16 @@ HINLINE hmm_quaternion HMM_DivideQuaternionF(hmm_quaternion Left, float Dividend
     return (Result);
 }
 
-HEXTERN hmm_quaternion HMM_InverseQuaternion(hmm_quaternion Left);
+HMM_EXTERN hmm_quaternion HMM_InverseQuaternion(hmm_quaternion Left);
 
-HINLINE float HMM_DotQuaternion(hmm_quaternion Left, hmm_quaternion Right)
+HMM_INLINE float HMM_DotQuaternion(hmm_quaternion Left, hmm_quaternion Right)
 {
     float Result = (Left.X * Right.X) + (Left.Y * Right.Y) + (Left.Z * Right.Z) + (Left.W * Right.W);
 
     return (Result);
 }
 
-HINLINE hmm_quaternion HMM_NormalizeQuaternion(hmm_quaternion Left)
+HMM_INLINE hmm_quaternion HMM_NormalizeQuaternion(hmm_quaternion Left)
 {
     hmm_quaternion Result;
 
@@ -1374,7 +1374,7 @@ HINLINE hmm_quaternion HMM_NormalizeQuaternion(hmm_quaternion Left)
     return (Result);
 }
 
-HINLINE hmm_quaternion HMM_NLerp(hmm_quaternion Left, float Time, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion HMM_NLerp(hmm_quaternion Left, float Time, hmm_quaternion Right)
 {
     hmm_quaternion Result;
 
@@ -1388,9 +1388,9 @@ HINLINE hmm_quaternion HMM_NLerp(hmm_quaternion Left, float Time, hmm_quaternion
     return (Result);
 }
 
-HEXTERN hmm_quaternion HMM_Slerp(hmm_quaternion Left, float Time, hmm_quaternion Right);
-HEXTERN hmm_mat4 HMM_QuaternionToMat4(hmm_quaternion Left);
-HEXTERN hmm_quaternion HMM_QuaternionFromAxisAngle(hmm_vec3 Axis, float AngleOfRotation);
+HMM_EXTERN hmm_quaternion HMM_Slerp(hmm_quaternion Left, float Time, hmm_quaternion Right);
+HMM_EXTERN hmm_mat4 HMM_QuaternionToMat4(hmm_quaternion Left);
+HMM_EXTERN hmm_quaternion HMM_QuaternionFromAxisAngle(hmm_vec3 Axis, float AngleOfRotation);
 
 #ifdef __cplusplus
 }
@@ -1398,722 +1398,722 @@ HEXTERN hmm_quaternion HMM_QuaternionFromAxisAngle(hmm_vec3 Axis, float AngleOfR
 
 #ifdef __cplusplus
 
-HINLINE float HMM_Length(hmm_vec2 A)
+HMM_INLINE float HMM_Length(hmm_vec2 A)
 {
     float Result = HMM_LengthVec2(A);
     
     return (Result);
 }
 
-HINLINE float HMM_Length(hmm_vec3 A)
+HMM_INLINE float HMM_Length(hmm_vec3 A)
 {
     float Result = HMM_LengthVec3(A);
     
     return (Result);
 }
 
-HINLINE float HMM_Length(hmm_vec4 A)
+HMM_INLINE float HMM_Length(hmm_vec4 A)
 {
     float Result = HMM_LengthVec4(A);
     
     return (Result);
 }
 
-HINLINE float HMM_LengthSquared(hmm_vec2 A)
+HMM_INLINE float HMM_LengthSquared(hmm_vec2 A)
 {
     float Result = HMM_LengthSquaredVec2(A);
     
     return (Result);
 }
 
-HINLINE float HMM_LengthSquared(hmm_vec3 A)
+HMM_INLINE float HMM_LengthSquared(hmm_vec3 A)
 {
     float Result = HMM_LengthSquaredVec3(A);
     
     return (Result);
 }
 
-HINLINE float HMM_LengthSquared(hmm_vec4 A)
+HMM_INLINE float HMM_LengthSquared(hmm_vec4 A)
 {
     float Result = HMM_LengthSquaredVec4(A);
     
     return (Result);
 }
 
-HINLINE hmm_vec2 HMM_Normalize(hmm_vec2 A)
+HMM_INLINE hmm_vec2 HMM_Normalize(hmm_vec2 A)
 {
     hmm_vec2 Result = HMM_NormalizeVec2(A);    
     
     return (Result);
 }
 
-HINLINE hmm_vec3 HMM_Normalize(hmm_vec3 A)
+HMM_INLINE hmm_vec3 HMM_Normalize(hmm_vec3 A)
 {
     hmm_vec3 Result = HMM_NormalizeVec3(A);
     
     return (Result);
 }
 
-HINLINE hmm_vec4 HMM_Normalize(hmm_vec4 A)
+HMM_INLINE hmm_vec4 HMM_Normalize(hmm_vec4 A)
 {
     hmm_vec4 Result = HMM_NormalizeVec4(A);
     
     return (Result);
 }
 
-HINLINE hmm_quaternion HMM_Normalize(hmm_quaternion A)
+HMM_INLINE hmm_quaternion HMM_Normalize(hmm_quaternion A)
 {
     hmm_quaternion Result = HMM_NormalizeQuaternion(A);
 
     return (Result);
 }
 
-HINLINE float HMM_Dot(hmm_vec2 VecOne, hmm_vec2 VecTwo)
+HMM_INLINE float HMM_Dot(hmm_vec2 VecOne, hmm_vec2 VecTwo)
 {
     float Result = HMM_DotVec2(VecOne, VecTwo);
     
     return (Result);
 }
 
-HINLINE float HMM_Dot(hmm_vec3 VecOne, hmm_vec3 VecTwo)
+HMM_INLINE float HMM_Dot(hmm_vec3 VecOne, hmm_vec3 VecTwo)
 {
     float Result = HMM_DotVec3(VecOne, VecTwo);
     
     return (Result);
 }
 
-HINLINE float HMM_Dot(hmm_vec4 VecOne, hmm_vec4 VecTwo)
+HMM_INLINE float HMM_Dot(hmm_vec4 VecOne, hmm_vec4 VecTwo)
 {
     float Result = HMM_DotVec4(VecOne, VecTwo);
     
     return (Result);
 }
 
-HINLINE float HMM_Dot(hmm_quaternion QuatOne, hmm_quaternion QuatTwo)
+HMM_INLINE float HMM_Dot(hmm_quaternion QuatOne, hmm_quaternion QuatTwo)
 {
     float Result = HMM_DotQuaternion(QuatOne, QuatTwo);
 
     return (Result);
 }
 
-HINLINE hmm_vec2 HMM_Add(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 HMM_Add(hmm_vec2 Left, hmm_vec2 Right)
 {
     hmm_vec2 Result = HMM_AddVec2(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec3 HMM_Add(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 HMM_Add(hmm_vec3 Left, hmm_vec3 Right)
 {
     hmm_vec3 Result = HMM_AddVec3(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec4 HMM_Add(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 HMM_Add(hmm_vec4 Left, hmm_vec4 Right)
 {
     hmm_vec4 Result = HMM_AddVec4(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_mat4 HMM_Add(hmm_mat4 Left, hmm_mat4 Right)
+HMM_INLINE hmm_mat4 HMM_Add(hmm_mat4 Left, hmm_mat4 Right)
 {
     hmm_mat4 Result = HMM_AddMat4(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_quaternion HMM_Add(hmm_quaternion Left, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion HMM_Add(hmm_quaternion Left, hmm_quaternion Right)
 {
     hmm_quaternion Result = HMM_AddQuaternion(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec2 HMM_Subtract(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 HMM_Subtract(hmm_vec2 Left, hmm_vec2 Right)
 {
     hmm_vec2 Result = HMM_SubtractVec2(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec3 HMM_Subtract(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 HMM_Subtract(hmm_vec3 Left, hmm_vec3 Right)
 {
     hmm_vec3 Result = HMM_SubtractVec3(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec4 HMM_Subtract(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 HMM_Subtract(hmm_vec4 Left, hmm_vec4 Right)
 {
     hmm_vec4 Result = HMM_SubtractVec4(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_mat4 HMM_Subtract(hmm_mat4 Left, hmm_mat4 Right)
+HMM_INLINE hmm_mat4 HMM_Subtract(hmm_mat4 Left, hmm_mat4 Right)
 {
     hmm_mat4 Result = HMM_SubtractMat4(Left, Right);
         
     return (Result);
 }
 
-HINLINE hmm_quaternion HMM_Subtract(hmm_quaternion Left, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion HMM_Subtract(hmm_quaternion Left, hmm_quaternion Right)
 {
     hmm_quaternion Result = HMM_SubtractQuaternion(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec2 HMM_Multiply(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 HMM_Multiply(hmm_vec2 Left, hmm_vec2 Right)
 {
     hmm_vec2 Result = HMM_MultiplyVec2(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec2 HMM_Multiply(hmm_vec2 Left, float Right)
+HMM_INLINE hmm_vec2 HMM_Multiply(hmm_vec2 Left, float Right)
 {
     hmm_vec2 Result = HMM_MultiplyVec2f(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec3 HMM_Multiply(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 HMM_Multiply(hmm_vec3 Left, hmm_vec3 Right)
 {
     hmm_vec3 Result = HMM_MultiplyVec3(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec3 HMM_Multiply(hmm_vec3 Left, float Right)
+HMM_INLINE hmm_vec3 HMM_Multiply(hmm_vec3 Left, float Right)
 {
     hmm_vec3 Result = HMM_MultiplyVec3f(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec4 HMM_Multiply(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 HMM_Multiply(hmm_vec4 Left, hmm_vec4 Right)
 {
     hmm_vec4 Result = HMM_MultiplyVec4(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec4 HMM_Multiply(hmm_vec4 Left, float Right)
+HMM_INLINE hmm_vec4 HMM_Multiply(hmm_vec4 Left, float Right)
 {
     hmm_vec4 Result = HMM_MultiplyVec4f(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_mat4 HMM_Multiply(hmm_mat4 Left, hmm_mat4 Right)
+HMM_INLINE hmm_mat4 HMM_Multiply(hmm_mat4 Left, hmm_mat4 Right)
 {
     hmm_mat4 Result = HMM_MultiplyMat4(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_mat4 HMM_Multiply(hmm_mat4 Left, float Right)
+HMM_INLINE hmm_mat4 HMM_Multiply(hmm_mat4 Left, float Right)
 {
     hmm_mat4 Result = HMM_MultiplyMat4f(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec4 HMM_Multiply(hmm_mat4 Matrix, hmm_vec4 Vector)
+HMM_INLINE hmm_vec4 HMM_Multiply(hmm_mat4 Matrix, hmm_vec4 Vector)
 {
     hmm_vec4 Result = HMM_MultiplyMat4ByVec4(Matrix, Vector);
     
     return (Result);
 }
 
-HINLINE hmm_quaternion HMM_Multiply(hmm_quaternion Left, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion HMM_Multiply(hmm_quaternion Left, hmm_quaternion Right)
 {
     hmm_quaternion Result = HMM_MultiplyQuaternion(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_quaternion HMM_Multiply(hmm_quaternion Left, float Right)
+HMM_INLINE hmm_quaternion HMM_Multiply(hmm_quaternion Left, float Right)
 {
     hmm_quaternion Result = HMM_MultiplyQuaternionF(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec2 HMM_Divide(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 HMM_Divide(hmm_vec2 Left, hmm_vec2 Right)
 {
     hmm_vec2 Result = HMM_DivideVec2(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec2 HMM_Divide(hmm_vec2 Left, float Right)
+HMM_INLINE hmm_vec2 HMM_Divide(hmm_vec2 Left, float Right)
 {
     hmm_vec2 Result = HMM_DivideVec2f(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec3 HMM_Divide(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 HMM_Divide(hmm_vec3 Left, hmm_vec3 Right)
 {
     hmm_vec3 Result = HMM_DivideVec3(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec3 HMM_Divide(hmm_vec3 Left, float Right)
+HMM_INLINE hmm_vec3 HMM_Divide(hmm_vec3 Left, float Right)
 {
     hmm_vec3 Result = HMM_DivideVec3f(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec4 HMM_Divide(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 HMM_Divide(hmm_vec4 Left, hmm_vec4 Right)
 {
     hmm_vec4 Result = HMM_DivideVec4(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec4 HMM_Divide(hmm_vec4 Left, float Right)
+HMM_INLINE hmm_vec4 HMM_Divide(hmm_vec4 Left, float Right)
 {
     hmm_vec4 Result = HMM_DivideVec4f(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_mat4 HMM_Divide(hmm_mat4 Left, float Right)
+HMM_INLINE hmm_mat4 HMM_Divide(hmm_mat4 Left, float Right)
 {
     hmm_mat4 Result = HMM_DivideMat4f(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_quaternion HMM_Divide(hmm_quaternion Left, float Right)
+HMM_INLINE hmm_quaternion HMM_Divide(hmm_quaternion Left, float Right)
 {
     hmm_quaternion Result = HMM_DivideQuaternionF(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_bool HMM_Equals(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_bool HMM_Equals(hmm_vec2 Left, hmm_vec2 Right)
 {
     hmm_bool Result = HMM_EqualsVec2(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_bool HMM_Equals(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_bool HMM_Equals(hmm_vec3 Left, hmm_vec3 Right)
 {
     hmm_bool Result = HMM_EqualsVec3(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_bool HMM_Equals(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_bool HMM_Equals(hmm_vec4 Left, hmm_vec4 Right)
 {
     hmm_bool Result = HMM_EqualsVec4(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec2 operator+(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 operator+(hmm_vec2 Left, hmm_vec2 Right)
 {
     hmm_vec2 Result = HMM_AddVec2(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec3 operator+(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 operator+(hmm_vec3 Left, hmm_vec3 Right)
 {
     hmm_vec3 Result = HMM_AddVec3(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec4 operator+(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 operator+(hmm_vec4 Left, hmm_vec4 Right)
 {
     hmm_vec4 Result = HMM_AddVec4(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_mat4 operator+(hmm_mat4 Left, hmm_mat4 Right)
+HMM_INLINE hmm_mat4 operator+(hmm_mat4 Left, hmm_mat4 Right)
 {
     hmm_mat4 Result = HMM_AddMat4(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_quaternion operator+(hmm_quaternion Left, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion operator+(hmm_quaternion Left, hmm_quaternion Right)
 {
     hmm_quaternion Result = HMM_AddQuaternion(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec2 operator-(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 operator-(hmm_vec2 Left, hmm_vec2 Right)
 {
     hmm_vec2 Result = HMM_SubtractVec2(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec3 operator-(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 operator-(hmm_vec3 Left, hmm_vec3 Right)
 {
     hmm_vec3 Result = HMM_SubtractVec3(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec4 operator-(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 operator-(hmm_vec4 Left, hmm_vec4 Right)
 {
     hmm_vec4 Result = HMM_SubtractVec4(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_mat4 operator-(hmm_mat4 Left, hmm_mat4 Right)
+HMM_INLINE hmm_mat4 operator-(hmm_mat4 Left, hmm_mat4 Right)
 {
     hmm_mat4 Result = HMM_SubtractMat4(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_quaternion operator-(hmm_quaternion Left, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion operator-(hmm_quaternion Left, hmm_quaternion Right)
 {
     hmm_quaternion Result = HMM_SubtractQuaternion(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec2 operator*(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 operator*(hmm_vec2 Left, hmm_vec2 Right)
 {
     hmm_vec2 Result = HMM_MultiplyVec2(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec3 operator*(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 operator*(hmm_vec3 Left, hmm_vec3 Right)
 {
     hmm_vec3 Result = HMM_MultiplyVec3(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec4 operator*(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 operator*(hmm_vec4 Left, hmm_vec4 Right)
 {
     hmm_vec4 Result = HMM_MultiplyVec4(Left, Right);
 
     return (Result);
 }
 
-HINLINE hmm_mat4 operator*(hmm_mat4 Left, hmm_mat4 Right)
+HMM_INLINE hmm_mat4 operator*(hmm_mat4 Left, hmm_mat4 Right)
 {
     hmm_mat4 Result = HMM_MultiplyMat4(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_quaternion operator*(hmm_quaternion Left, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion operator*(hmm_quaternion Left, hmm_quaternion Right)
 {
     hmm_quaternion Result = HMM_MultiplyQuaternion(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec2 operator*(hmm_vec2 Left, float Right)
+HMM_INLINE hmm_vec2 operator*(hmm_vec2 Left, float Right)
 {
     hmm_vec2 Result = HMM_MultiplyVec2f(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec3 operator*(hmm_vec3 Left, float Right)
+HMM_INLINE hmm_vec3 operator*(hmm_vec3 Left, float Right)
 {
     hmm_vec3 Result = HMM_MultiplyVec3f(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec4 operator*(hmm_vec4 Left, float Right)
+HMM_INLINE hmm_vec4 operator*(hmm_vec4 Left, float Right)
 {
     hmm_vec4 Result = HMM_MultiplyVec4f(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_mat4 operator*(hmm_mat4 Left, float Right)
+HMM_INLINE hmm_mat4 operator*(hmm_mat4 Left, float Right)
 {
     hmm_mat4 Result = HMM_MultiplyMat4f(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_quaternion operator*(hmm_quaternion Left, float Right)
+HMM_INLINE hmm_quaternion operator*(hmm_quaternion Left, float Right)
 {
     hmm_quaternion Result = HMM_MultiplyQuaternionF(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec2 operator*(float Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 operator*(float Left, hmm_vec2 Right)
 {
     hmm_vec2 Result = HMM_MultiplyVec2f(Right, Left);
     
     return (Result);
 }
 
-HINLINE hmm_vec3 operator*(float Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 operator*(float Left, hmm_vec3 Right)
 {
     hmm_vec3 Result = HMM_MultiplyVec3f(Right, Left);
 
     return (Result);
 }
 
-HINLINE hmm_vec4 operator*(float Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 operator*(float Left, hmm_vec4 Right)
 {
     hmm_vec4 Result = HMM_MultiplyVec4f(Right, Left);
 
     return (Result);
 }
 
-HINLINE hmm_mat4 operator*(float Left, hmm_mat4 Right)
+HMM_INLINE hmm_mat4 operator*(float Left, hmm_mat4 Right)
 {
     hmm_mat4 Result = HMM_MultiplyMat4f(Right, Left);
 
     return (Result);
 }
 
-HINLINE hmm_quaternion operator*(float Left, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion operator*(float Left, hmm_quaternion Right)
 {
     hmm_quaternion Result = HMM_MultiplyQuaternionF(Right, Left);
 
     return (Result);
 }
 
-HINLINE hmm_vec4 operator*(hmm_mat4 Matrix, hmm_vec4 Vector)
+HMM_INLINE hmm_vec4 operator*(hmm_mat4 Matrix, hmm_vec4 Vector)
 {
     hmm_vec4 Result = HMM_MultiplyMat4ByVec4(Matrix, Vector);
 
     return (Result);
 }
 
-HINLINE hmm_vec2 operator/(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 operator/(hmm_vec2 Left, hmm_vec2 Right)
 {
     hmm_vec2 Result = HMM_DivideVec2(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec3 operator/(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 operator/(hmm_vec3 Left, hmm_vec3 Right)
 {
     hmm_vec3 Result = HMM_DivideVec3(Left, Right);
 
     return (Result);
 }
 
-HINLINE hmm_vec4 operator/(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 operator/(hmm_vec4 Left, hmm_vec4 Right)
 {
     hmm_vec4 Result = HMM_DivideVec4(Left, Right);
 
     return (Result);
 }
 
-HINLINE hmm_vec2 operator/(hmm_vec2 Left, float Right)
+HMM_INLINE hmm_vec2 operator/(hmm_vec2 Left, float Right)
 {
     hmm_vec2 Result = HMM_DivideVec2f(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec3 operator/(hmm_vec3 Left, float Right)
+HMM_INLINE hmm_vec3 operator/(hmm_vec3 Left, float Right)
 {
     hmm_vec3 Result = HMM_DivideVec3f(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec4 operator/(hmm_vec4 Left, float Right)
+HMM_INLINE hmm_vec4 operator/(hmm_vec4 Left, float Right)
 {
     hmm_vec4 Result = HMM_DivideVec4f(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_mat4 operator/(hmm_mat4 Left, float Right)
+HMM_INLINE hmm_mat4 operator/(hmm_mat4 Left, float Right)
 {
     hmm_mat4 Result = HMM_DivideMat4f(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_quaternion operator/(hmm_quaternion Left, float Right)
+HMM_INLINE hmm_quaternion operator/(hmm_quaternion Left, float Right)
 {
     hmm_quaternion Result = HMM_DivideQuaternionF(Left, Right);
     
     return (Result);
 }
 
-HINLINE hmm_vec2 &operator+=(hmm_vec2 &Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 &operator+=(hmm_vec2 &Left, hmm_vec2 Right)
 {
     return (Left = Left + Right);
 }
 
-HINLINE hmm_vec3 &operator+=(hmm_vec3 &Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 &operator+=(hmm_vec3 &Left, hmm_vec3 Right)
 {
     return (Left = Left + Right);
 }
 
-HINLINE hmm_vec4 &operator+=(hmm_vec4 &Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 &operator+=(hmm_vec4 &Left, hmm_vec4 Right)
 {
     return (Left = Left + Right);
 }
 
-HINLINE hmm_mat4 &operator+=(hmm_mat4 &Left, hmm_mat4 Right)
+HMM_INLINE hmm_mat4 &operator+=(hmm_mat4 &Left, hmm_mat4 Right)
 {
     return (Left = Left + Right);
 }
 
-HINLINE hmm_quaternion &operator+=(hmm_quaternion &Left, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion &operator+=(hmm_quaternion &Left, hmm_quaternion Right)
 {
     return (Left = Left + Right);
 }
 
-HINLINE hmm_vec2 &operator-=(hmm_vec2 &Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 &operator-=(hmm_vec2 &Left, hmm_vec2 Right)
 {
     return (Left = Left - Right);
 }
 
-HINLINE hmm_vec3 &operator-=(hmm_vec3 &Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 &operator-=(hmm_vec3 &Left, hmm_vec3 Right)
 {
     return (Left = Left - Right);
 }
 
-HINLINE hmm_vec4 &operator-=(hmm_vec4 &Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 &operator-=(hmm_vec4 &Left, hmm_vec4 Right)
 {
     return (Left = Left - Right);
 }
 
-HINLINE hmm_mat4 &operator-=(hmm_mat4 &Left, hmm_mat4 Right)
+HMM_INLINE hmm_mat4 &operator-=(hmm_mat4 &Left, hmm_mat4 Right)
 {
     return (Left = Left - Right);
 }
 
-HINLINE hmm_quaternion &operator-=(hmm_quaternion &Left, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion &operator-=(hmm_quaternion &Left, hmm_quaternion Right)
 {
     return (Left = Left - Right);
 }
 
-HINLINE hmm_vec2 &operator*=(hmm_vec2 &Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 &operator*=(hmm_vec2 &Left, hmm_vec2 Right)
 {
     return (Left = Left * Right);
 }
 
-HINLINE hmm_vec3 &operator*=(hmm_vec3 &Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 &operator*=(hmm_vec3 &Left, hmm_vec3 Right)
 {
     return (Left = Left * Right);
 }
 
-HINLINE hmm_vec4 &operator*=(hmm_vec4 &Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 &operator*=(hmm_vec4 &Left, hmm_vec4 Right)
 {
     return (Left = Left * Right);
 }
 
-HINLINE hmm_vec2 &operator*=(hmm_vec2 &Left, float Right)
+HMM_INLINE hmm_vec2 &operator*=(hmm_vec2 &Left, float Right)
 {
     return (Left = Left * Right);
 }
 
-HINLINE hmm_vec3 &operator*=(hmm_vec3 &Left, float Right)
+HMM_INLINE hmm_vec3 &operator*=(hmm_vec3 &Left, float Right)
 {
     return (Left = Left * Right);
 }
 
-HINLINE hmm_vec4 &operator*=(hmm_vec4 &Left, float Right)
+HMM_INLINE hmm_vec4 &operator*=(hmm_vec4 &Left, float Right)
 {
     return (Left = Left * Right);
 }
 
-HINLINE hmm_mat4 &operator*=(hmm_mat4 &Left, float Right)
+HMM_INLINE hmm_mat4 &operator*=(hmm_mat4 &Left, float Right)
 {
     return (Left = Left * Right);
 }
 
-HINLINE hmm_quaternion &operator*=(hmm_quaternion &Left, float Right)
+HMM_INLINE hmm_quaternion &operator*=(hmm_quaternion &Left, float Right)
 {
     return (Left = Left * Right);
 }
 
-HINLINE hmm_vec2 &operator/=(hmm_vec2 &Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 &operator/=(hmm_vec2 &Left, hmm_vec2 Right)
 {
     return (Left = Left / Right);
 }
 
-HINLINE hmm_vec3 &operator/=(hmm_vec3 &Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 &operator/=(hmm_vec3 &Left, hmm_vec3 Right)
 {
     return (Left = Left / Right);
 }
 
-HINLINE hmm_vec4 &operator/=(hmm_vec4 &Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 &operator/=(hmm_vec4 &Left, hmm_vec4 Right)
 {
     return (Left = Left / Right);
 }
 
-HINLINE hmm_vec2 &operator/=(hmm_vec2 &Left, float Right)
+HMM_INLINE hmm_vec2 &operator/=(hmm_vec2 &Left, float Right)
 {
     return (Left = Left / Right);
 }
 
-HINLINE hmm_vec3 &operator/=(hmm_vec3 &Left, float Right)
+HMM_INLINE hmm_vec3 &operator/=(hmm_vec3 &Left, float Right)
 {
     return (Left = Left / Right);
 }
 
-HINLINE hmm_vec4 &operator/=(hmm_vec4 &Left, float Right)
+HMM_INLINE hmm_vec4 &operator/=(hmm_vec4 &Left, float Right)
 {
     return (Left = Left / Right);
 }
 
-HINLINE hmm_mat4 &operator/=(hmm_mat4 &Left, float Right)
+HMM_INLINE hmm_mat4 &operator/=(hmm_mat4 &Left, float Right)
 {
     return (Left = Left / Right);
 }
 
-HINLINE hmm_quaternion &operator/=(hmm_quaternion &Left, float Right)
+HMM_INLINE hmm_quaternion &operator/=(hmm_quaternion &Left, float Right)
 {
     return (Left = Left / Right);
 }
 
-HINLINE hmm_bool operator==(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_bool operator==(hmm_vec2 Left, hmm_vec2 Right)
 {
     return HMM_EqualsVec2(Left, Right);
 }
 
-HINLINE hmm_bool operator==(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_bool operator==(hmm_vec3 Left, hmm_vec3 Right)
 {
     return HMM_EqualsVec3(Left, Right);
 }
 
-HINLINE hmm_bool operator==(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_bool operator==(hmm_vec4 Left, hmm_vec4 Right)
 {
     return HMM_EqualsVec4(Left, Right);
 }
 
-HINLINE hmm_bool operator!=(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_bool operator!=(hmm_vec2 Left, hmm_vec2 Right)
 {
     return !HMM_EqualsVec2(Left, Right);
 }
 
-HINLINE hmm_bool operator!=(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_bool operator!=(hmm_vec3 Left, hmm_vec3 Right)
 {
     return !HMM_EqualsVec3(Left, Right);
 }
 
-HINLINE hmm_bool operator!=(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_bool operator!=(hmm_vec4 Left, hmm_vec4 Right)
 {
     return !HMM_EqualsVec4(Left, Right);
 }

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -252,19 +252,8 @@ extern "C"
 {
 #endif
 
-#ifdef HANDMADE_MATH_STATIC
-#define HMMDEF static
-#else
-#define HMMDEF extern
-#endif
-
-#ifdef HANDMADE_MATH_NO_INLINE
-#define HINLINE
-#elif _MSC_VER && !__INTEL_COMPILER
-#define HINLINE __inline
-#else
-#define HINLINE inline
-#endif
+#define HINLINE static inline
+#define HEXTERN extern
 
 #if !defined(HMM_SINF) || !defined(HMM_COSF) || !defined(HMM_TANF) || \
     !defined(HMM_SQRTF) || !defined(HMM_EXPF) || !defined(HMM_LOGF) || \
@@ -478,454 +467,98 @@ typedef hmm_vec3 hmm_v3;
 typedef hmm_vec4 hmm_v4;
 typedef hmm_mat4 hmm_m4;    
 
-HMMDEF float HMM_SinF(float Angle);
-HMMDEF float HMM_TanF(float Angle);
-HMMDEF float HMM_ATanF(float Theta);
-HMMDEF float HMM_ATan2F(float Theta, float Theta2);
-HMMDEF float HMM_CosF(float Angle);
-HMMDEF float HMM_ACosF(float Theta);
-HMMDEF float HMM_ExpF(float Float);
-HMMDEF float HMM_LogF(float Float);
 
-HMMDEF float HMM_ToRadians(float Degrees);
-HMMDEF float HMM_SquareRootF(float Float);
-HMMDEF float HMM_RSquareRootF(float Float);
+/*
+ * Floating-point math functions
+ */
 
-HMMDEF float HMM_LengthSquaredVec2(hmm_vec2 A);
-HMMDEF float HMM_LengthSquaredVec3(hmm_vec3 A);
-HMMDEF float HMM_LengthSquaredVec4(hmm_vec4 A);
-
-HMMDEF float HMM_LengthVec2(hmm_vec2 A);    
-HMMDEF float HMM_LengthVec3(hmm_vec3 A);    
-HMMDEF float HMM_LengthVec4(hmm_vec4 A);    
-
-HMMDEF float HMM_Power(float Base, int Exponent);
-HMMDEF float HMM_PowerF(float Base, float Exponent);
-HMMDEF float HMM_Lerp(float A, float Time, float B);
-HMMDEF float HMM_Clamp(float Min, float Value, float Max);
-
-HMMDEF hmm_vec2 HMM_NormalizeVec2(hmm_vec2 A);
-HMMDEF hmm_vec3 HMM_NormalizeVec3(hmm_vec3 A);
-HMMDEF hmm_vec4 HMM_NormalizeVec4(hmm_vec4 A);
-
-HMMDEF float HMM_DotVec2(hmm_vec2 VecOne, hmm_vec2 VecTwo);
-HMMDEF float HMM_DotVec3(hmm_vec3 VecOne, hmm_vec3 VecTwo);
-HMMDEF float HMM_DotVec4(hmm_vec4 VecOne, hmm_vec4 VecTwo);
-
-HMMDEF hmm_vec3 HMM_Cross(hmm_vec3 VecOne, hmm_vec3 VecTwo);
-
-HMMDEF hmm_vec2 HMM_Vec2(float X, float Y);
-HMMDEF hmm_vec2 HMM_Vec2i(int X, int Y);
-HMMDEF hmm_vec3 HMM_Vec3(float X, float Y, float Z);
-HMMDEF hmm_vec3 HMM_Vec3i(int X, int Y, int Z);
-HMMDEF hmm_vec4 HMM_Vec4(float X, float Y, float Z, float W);
-HMMDEF hmm_vec4 HMM_Vec4i(int X, int Y, int Z, int W);
-HMMDEF hmm_vec4 HMM_Vec4v(hmm_vec3 Vector, float W);
-
-HMMDEF hmm_vec2 HMM_AddVec2(hmm_vec2 Left, hmm_vec2 Right);
-HMMDEF hmm_vec3 HMM_AddVec3(hmm_vec3 Left, hmm_vec3 Right);
-HMMDEF hmm_vec4 HMM_AddVec4(hmm_vec4 Left, hmm_vec4 Right);
-
-HMMDEF hmm_vec2 HMM_SubtractVec2(hmm_vec2 Left, hmm_vec2 Right);
-HMMDEF hmm_vec3 HMM_SubtractVec3(hmm_vec3 Left, hmm_vec3 Right);
-HMMDEF hmm_vec4 HMM_SubtractVec4(hmm_vec4 Left, hmm_vec4 Right);
-
-HMMDEF hmm_vec2 HMM_MultiplyVec2(hmm_vec2 Left, hmm_vec2 Right);
-HMMDEF hmm_vec2 HMM_MultiplyVec2f(hmm_vec2 Left, float Right);
-HMMDEF hmm_vec3 HMM_MultiplyVec3(hmm_vec3 Left, hmm_vec3 Right);
-HMMDEF hmm_vec3 HMM_MultiplyVec3f(hmm_vec3 Left, float Right);
-HMMDEF hmm_vec4 HMM_MultiplyVec4(hmm_vec4 Left, hmm_vec4 Right);
-HMMDEF hmm_vec4 HMM_MultiplyVec4f(hmm_vec4 Left, float Right);
-
-HMMDEF hmm_vec2 HMM_DivideVec2(hmm_vec2 Left, hmm_vec2 Right);
-HMMDEF hmm_vec2 HMM_DivideVec2f(hmm_vec2 Left, float Right);
-HMMDEF hmm_vec3 HMM_DivideVec3(hmm_vec3 Left, hmm_vec3 Right);
-HMMDEF hmm_vec3 HMM_DivideVec3f(hmm_vec3 Left, float Right);
-HMMDEF hmm_vec4 HMM_DivideVec4(hmm_vec4 Left, hmm_vec4 Right);
-HMMDEF hmm_vec4 HMM_DivideVec4f(hmm_vec4 Left, float Right);
-
-HMMDEF hmm_bool HMM_EqualsVec2(hmm_vec2 Left, hmm_vec2 Right);
-HMMDEF hmm_bool HMM_EqualsVec3(hmm_vec3 Left, hmm_vec3 Right);
-HMMDEF hmm_bool HMM_EqualsVec4(hmm_vec4 Left, hmm_vec4 Right);
-
-HMMDEF hmm_mat4 HMM_Mat4(void);
-HMMDEF hmm_mat4 HMM_Mat4d(float Diagonal);
-HMMDEF hmm_mat4 HMM_AddMat4(hmm_mat4 Left, hmm_mat4 Right);
-HMMDEF hmm_mat4 HMM_SubtractMat4(hmm_mat4 Left, hmm_mat4 Right);
-
-#ifdef HANDMADE_MATH__USE_SSE
-HMMDEF __m128 HMM_LinearCombineSSE(__m128 Left, hmm_mat4 Right);
-#endif 
-
-HMMDEF hmm_mat4 HMM_MultiplyMat4(hmm_mat4 Left, hmm_mat4 Right);
-HMMDEF hmm_mat4 HMM_MultiplyMat4f(hmm_mat4 Matrix, float Scalar);
-HMMDEF hmm_vec4 HMM_MultiplyMat4ByVec4(hmm_mat4 Matrix, hmm_vec4 Vector);
-HMMDEF hmm_mat4 HMM_DivideMat4f(hmm_mat4 Matrix, float Scalar);
-
-HMMDEF hmm_mat4 HMM_Transpose(hmm_mat4 Matrix);
-
-HMMDEF hmm_mat4 HMM_Orthographic(float Left, float Right, float Bottom, float Top, float Near, float Far);
-HMMDEF hmm_mat4 HMM_Perspective(float FOV, float AspectRatio, float Near, float Far);
-
-HMMDEF hmm_mat4 HMM_Translate(hmm_vec3 Translation);
-HMMDEF hmm_mat4 HMM_Rotate(float Angle, hmm_vec3 Axis);
-HMMDEF hmm_mat4 HMM_Scale(hmm_vec3 Scale);
-
-HMMDEF hmm_mat4 HMM_LookAt(hmm_vec3 Eye, hmm_vec3 Center, hmm_vec3 Up);
-
-HMMDEF hmm_quaternion HMM_Quaternion(float X, float Y, float Z, float W);
-HMMDEF hmm_quaternion HMM_QuaternionV4(hmm_vec4 Vector);
-HMMDEF hmm_quaternion HMM_AddQuaternion(hmm_quaternion Left, hmm_quaternion Right);
-HMMDEF hmm_quaternion HMM_SubtractQuaternion(hmm_quaternion Left, hmm_quaternion Right);
-HMMDEF hmm_quaternion HMM_MultiplyQuaternion(hmm_quaternion Left, hmm_quaternion Right);
-HMMDEF hmm_quaternion HMM_MultiplyQuaternionF(hmm_quaternion Left, float Multiplicative);
-HMMDEF hmm_quaternion HMM_DivideQuaternionF(hmm_quaternion Left, float Dividend);
-HMMDEF hmm_quaternion HMM_InverseQuaternion(hmm_quaternion Left);
-HMMDEF float HMM_DotQuaternion(hmm_quaternion Left, hmm_quaternion Right);
-HMMDEF hmm_quaternion HMM_NormalizeQuaternion(hmm_quaternion Left);
-HMMDEF hmm_quaternion HMM_NLerp(hmm_quaternion Left, float Time, hmm_quaternion Right);
-HMMDEF hmm_quaternion HMM_Slerp(hmm_quaternion Left, float Time, hmm_quaternion Right);
-HMMDEF hmm_mat4 HMM_QuaternionToMat4(hmm_quaternion Left);
-HMMDEF hmm_quaternion HMM_QuaternionFromAxisAngle(hmm_vec3 Axis, float AngleOfRotation);
-
-#ifdef __cplusplus
-}
-#endif
-
-#ifdef __cplusplus
-
-HMMDEF float HMM_Length(hmm_vec2 A);
-HMMDEF float HMM_Length(hmm_vec3 A);
-HMMDEF float HMM_Length(hmm_vec4 A);
-
-HMMDEF float HMM_LengthSquared(hmm_vec2 A);
-HMMDEF float HMM_LengthSquared(hmm_vec3 A);
-HMMDEF float HMM_LengthSquared(hmm_vec4 A);
-
-HMMDEF hmm_vec2 HMM_Normalize(hmm_vec2 A);
-HMMDEF hmm_vec3 HMM_Normalize(hmm_vec3 A);
-HMMDEF hmm_vec4 HMM_Normalize(hmm_vec4 A);
-HMMDEF hmm_quaternion HMM_Normalize(hmm_quaternion A);
-
-HMMDEF float HMM_Dot(hmm_vec2 VecOne, hmm_vec2 VecTwo);
-HMMDEF float HMM_Dot(hmm_vec3 VecOne, hmm_vec3 VecTwo);
-HMMDEF float HMM_Dot(hmm_vec4 VecOne, hmm_vec4 VecTwo);
-HMMDEF float HMM_Dot(hmm_quaternion QuatOne, hmm_quaternion QuatTwo);
-
-HMMDEF hmm_vec2 HMM_Add(hmm_vec2 Left, hmm_vec2 Right);
-HMMDEF hmm_vec3 HMM_Add(hmm_vec3 Left, hmm_vec3 Right);
-HMMDEF hmm_vec4 HMM_Add(hmm_vec4 Left, hmm_vec4 Right);
-HMMDEF hmm_mat4 HMM_Add(hmm_mat4 Left, hmm_mat4 Right);
-HMMDEF hmm_quaternion HMM_Add(hmm_quaternion Left, hmm_quaternion Right);
-
-HMMDEF hmm_vec2 HMM_Subtract(hmm_vec2 Left, hmm_vec2 Right);
-HMMDEF hmm_vec3 HMM_Subtract(hmm_vec3 Left, hmm_vec3 Right);
-HMMDEF hmm_vec4 HMM_Subtract(hmm_vec4 Left, hmm_vec4 Right);
-HMMDEF hmm_mat4 HMM_Subtract(hmm_mat4 Left, hmm_mat4 Right);
-HMMDEF hmm_quaternion HMM_Subtract(hmm_quaternion Left, hmm_quaternion Right);
-
-HMMDEF hmm_vec2 HMM_Multiply(hmm_vec2 Left, hmm_vec2 Right);
-HMMDEF hmm_vec2 HMM_Multiply(hmm_vec2 Left, float Right);
-HMMDEF hmm_vec3 HMM_Multiply(hmm_vec3 Left, hmm_vec3 Right);
-HMMDEF hmm_vec3 HMM_Multiply(hmm_vec3 Left, float Right);
-HMMDEF hmm_vec4 HMM_Multiply(hmm_vec4 Left, hmm_vec4 Right);
-HMMDEF hmm_vec4 HMM_Multiply(hmm_vec4 Left, float Right);
-HMMDEF hmm_mat4 HMM_Multiply(hmm_mat4 Left, hmm_mat4 Right);
-HMMDEF hmm_mat4 HMM_Multiply(hmm_mat4 Left, float Right);
-HMMDEF hmm_vec4 HMM_Multiply(hmm_mat4 Matrix, hmm_vec4 Vector);
-HMMDEF hmm_quaternion HMM_Multiply(hmm_quaternion Left, hmm_quaternion Right);
-HMMDEF hmm_quaternion HMM_Multiply(hmm_quaternion Left, float Right);
-
-HMMDEF hmm_vec2 HMM_Divide(hmm_vec2 Left, hmm_vec2 Right);
-HMMDEF hmm_vec2 HMM_Divide(hmm_vec2 Left, float Right);
-HMMDEF hmm_vec3 HMM_Divide(hmm_vec3 Left, hmm_vec3 Right);
-HMMDEF hmm_vec3 HMM_Divide(hmm_vec3 Left, float Right);
-HMMDEF hmm_vec4 HMM_Divide(hmm_vec4 Left, hmm_vec4 Right);
-HMMDEF hmm_vec4 HMM_Divide(hmm_vec4 Left, float Right);
-HMMDEF hmm_mat4 HMM_Divide(hmm_mat4 Left, float Right);
-HMMDEF hmm_quaternion HMM_Divide(hmm_quaternion Left, hmm_quaternion Right);
-HMMDEF hmm_quaternion HMM_Divide(hmm_quaternion Left, float Right);
-
-HMMDEF hmm_bool HMM_Equals(hmm_vec2 Left, hmm_vec2 Right);
-HMMDEF hmm_bool HMM_Equals(hmm_vec3 Left, hmm_vec3 Right);
-HMMDEF hmm_bool HMM_Equals(hmm_vec4 Left, hmm_vec4 Right);
-
-HMMDEF hmm_vec2 operator+(hmm_vec2 Left, hmm_vec2 Right);
-HMMDEF hmm_vec3 operator+(hmm_vec3 Left, hmm_vec3 Right);
-HMMDEF hmm_vec4 operator+(hmm_vec4 Left, hmm_vec4 Right);
-HMMDEF hmm_mat4 operator+(hmm_mat4 Left, hmm_mat4 Right);
-HMMDEF hmm_quaternion operator+(hmm_quaternion Left, hmm_quaternion Right);
-
-HMMDEF hmm_vec2 operator-(hmm_vec2 Left, hmm_vec2 Right);
-HMMDEF hmm_vec3 operator-(hmm_vec3 Left, hmm_vec3 Right);
-HMMDEF hmm_vec4 operator-(hmm_vec4 Left, hmm_vec4 Right);
-HMMDEF hmm_mat4 operator-(hmm_mat4 Left, hmm_mat4 Right);
-HMMDEF hmm_quaternion operator-(hmm_quaternion Left, hmm_quaternion Right);
-
-HMMDEF hmm_vec2 operator*(hmm_vec2 Left, hmm_vec2 Right);
-HMMDEF hmm_vec3 operator*(hmm_vec3 Left, hmm_vec3 Right);
-HMMDEF hmm_vec4 operator*(hmm_vec4 Left, hmm_vec4 Right);
-HMMDEF hmm_mat4 operator*(hmm_mat4 Left, hmm_mat4 Right);
-HMMDEF hmm_quaternion operator*(hmm_quaternion Left, hmm_quaternion Right);
-
-HMMDEF hmm_vec2 operator*(hmm_vec2 Left, float Right);
-HMMDEF hmm_vec3 operator*(hmm_vec3 Left, float Right);
-HMMDEF hmm_vec4 operator*(hmm_vec4 Left, float Right);
-HMMDEF hmm_mat4 operator*(hmm_mat4 Left, float Right);
-HMMDEF hmm_quaternion operator*(hmm_quaternion Left, float Right);
-
-HMMDEF hmm_vec2 operator*(float Left, hmm_vec2 Right);
-HMMDEF hmm_vec3 operator*(float Left, hmm_vec3 Right);
-HMMDEF hmm_vec4 operator*(float Left, hmm_vec4 Right);
-HMMDEF hmm_mat4 operator*(float Left, hmm_mat4 Right);
-HMMDEF hmm_quaternion operator*(float Left, hmm_quaternion Right);
-
-HMMDEF hmm_vec4 operator*(hmm_mat4 Matrix, hmm_vec4 Vector);
-
-HMMDEF hmm_vec2 operator/(hmm_vec2 Left, hmm_vec2 Right);
-HMMDEF hmm_vec3 operator/(hmm_vec3 Left, hmm_vec3 Right);
-HMMDEF hmm_vec4 operator/(hmm_vec4 Left, hmm_vec4 Right);
-
-HMMDEF hmm_vec2 operator/(hmm_vec2 Left, float Right);
-HMMDEF hmm_vec3 operator/(hmm_vec3 Left, float Right);
-HMMDEF hmm_vec4 operator/(hmm_vec4 Left, float Right);
-HMMDEF hmm_mat4 operator/(hmm_mat4 Left, float Right);
-HMMDEF hmm_quaternion operator/(hmm_quaternion Left, float Right);
-
-HMMDEF hmm_vec2 &operator+=(hmm_vec2 &Left, hmm_vec2 Right);
-HMMDEF hmm_vec3 &operator+=(hmm_vec3 &Left, hmm_vec3 Right);
-HMMDEF hmm_vec4 &operator+=(hmm_vec4 &Left, hmm_vec4 Right);
-HMMDEF hmm_mat4 &operator+=(hmm_mat4 &Left, hmm_mat4 Right);
-HMMDEF hmm_quaternion &operator+=(hmm_quaternion &Left, hmm_quaternion Right);
-
-HMMDEF hmm_vec2 &operator-=(hmm_vec2 &Left, hmm_vec2 Right);
-HMMDEF hmm_vec3 &operator-=(hmm_vec3 &Left, hmm_vec3 Right);
-HMMDEF hmm_vec4 &operator-=(hmm_vec4 &Left, hmm_vec4 Right);
-HMMDEF hmm_mat4 &operator-=(hmm_mat4 &Left, hmm_mat4 Right);
-HMMDEF hmm_quaternion &operator-=(hmm_quaternion &Left, hmm_quaternion Right);
-
-HMMDEF hmm_vec2 &operator*=(hmm_vec2 &Left, hmm_vec2 Right);
-HMMDEF hmm_vec3 &operator*=(hmm_vec3 &Left, hmm_vec3 Right);
-HMMDEF hmm_vec4 &operator*=(hmm_vec4 &Left, hmm_vec4 Right);
-
-HMMDEF hmm_vec2 &operator*=(hmm_vec2 &Left, float Right);
-HMMDEF hmm_vec3 &operator*=(hmm_vec3 &Left, float Right);
-HMMDEF hmm_vec4 &operator*=(hmm_vec4 &Left, float Right);
-HMMDEF hmm_mat4 &operator*=(hmm_mat4 &Left, float Right);
-HMMDEF hmm_quaternion &operator*=(hmm_quaternion &Left, float Right);
-
-HMMDEF hmm_vec2 &operator/=(hmm_vec2 &Left, hmm_vec2 Right);
-HMMDEF hmm_vec3 &operator/=(hmm_vec3 &Left, hmm_vec3 Right);
-HMMDEF hmm_vec4 &operator/=(hmm_vec4 &Left, hmm_vec4 Right);
-
-HMMDEF hmm_vec2 &operator/=(hmm_vec2 &Left, float Right);
-HMMDEF hmm_vec3 &operator/=(hmm_vec3 &Left, float Right);
-HMMDEF hmm_vec4 &operator/=(hmm_vec4 &Left, float Right);
-HMMDEF hmm_mat4 &operator/=(hmm_mat4 &Left, float Right);
-HMMDEF hmm_quaternion &operator/=(hmm_quaternion &Left, float Right);
-
-HMMDEF hmm_bool operator==(hmm_vec2 Left, hmm_vec2 Right);
-HMMDEF hmm_bool operator==(hmm_vec3 Left, hmm_vec3 Right);
-HMMDEF hmm_bool operator==(hmm_vec4 Left, hmm_vec4 Right);
-
-HMMDEF hmm_bool operator!=(hmm_vec2 Left, hmm_vec2 Right);
-HMMDEF hmm_bool operator!=(hmm_vec3 Left, hmm_vec3 Right);
-HMMDEF hmm_bool operator!=(hmm_vec4 Left, hmm_vec4 Right);
-
-#endif /* __cplusplus */
-
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
-
-#endif /* HANDMADE_MATH_H */
-
-#ifdef HANDMADE_MATH_IMPLEMENTATION
-
-HINLINE float
-HMM_SinF(float Angle)
+HINLINE float HMM_SinF(float Radians)
 {
-    float Result;
-
-    Result = HMM_SINF(Angle);
+    float Result = HMM_SINF(Radians);
     
     return (Result);
 }
 
-HINLINE float
-HMM_CosF(float Angle)
+HINLINE float HMM_CosF(float Radians)
 {
-    float Result;
-
-    Result = HMM_COSF(Angle);
+    float Result = HMM_COSF(Radians);
     
     return (Result);
 }
 
-HINLINE float
-HMM_TanF(float Radians)
+HINLINE float HMM_TanF(float Radians)
 {
-    float Result;
-
-    Result = HMM_TANF(Radians);
+    float Result = HMM_TANF(Radians);
     
     return (Result);
 }
 
-HINLINE float
-HMM_ACosF(float Radians)
+HINLINE float HMM_ACosF(float Radians)
 {
-    float Result;
-
-    Result = HMM_ACOSF(Radians);
+    float Result = HMM_ACOSF(Radians);
     
     return (Result);
 }
 
-HINLINE float
-HMM_ATanF(float Radians)
+HINLINE float HMM_ATanF(float Radians)
 {
-    float Result;
-
-    Result = HMM_ATANF(Radians);
+    float Result = HMM_ATANF(Radians);
     
     return (Result);
 }
 
-HINLINE float
-HMM_Atan2F(float Left, float Right)
+HINLINE float HMM_ATan2F(float Left, float Right)
 {
-    float Result;
-
-    Result = HMM_ATAN2F(Left, Right);
+    float Result = HMM_ATAN2F(Left, Right);
     
     return (Result);
 }
 
-HINLINE float
-HMM_ExpF(float Float)
+HINLINE float HMM_ExpF(float Float)
 {
-    float Result;
-
-    Result = HMM_EXPF(Float);
+    float Result = HMM_EXPF(Float);
     
     return (Result);
 }
 
-HINLINE float
-HMM_LogF(float Float)
+HINLINE float HMM_LogF(float Float)
 {
-    float Result;
-
-    Result = HMM_LOGF(Float);
+    float Result = HMM_LOGF(Float);
     
     return (Result);
 }
 
-HINLINE float
-HMM_ToRadians(float Degrees)
-{
-    float Result;
-
-    Result = Degrees * (HMM_PI32 / 180.0f);
-    
-    return (Result);
-}
-
-HINLINE float
-HMM_SquareRootF(float Value)
+HINLINE float HMM_SquareRootF(float Float)
 {
     float Result;
 
 #ifdef HANDMADE_MATH__USE_SSE
-    __m128 In = _mm_set_ss(Value);
+    __m128 In = _mm_set_ss(Float);
     __m128 Out = _mm_sqrt_ss(In);
     Result = _mm_cvtss_f32(Out);
 #else
-    Result = HMM_SQRTF(Value);
+    Result = HMM_SQRTF(Float);
 #endif 
 
     return(Result);
 }
 
-HINLINE float
-HMM_RSquareRootF(float Value)
+HINLINE float HMM_RSquareRootF(float Float)
 {
     float Result;
 
 #ifdef HANDMADE_MATH__USE_SSE
-    __m128 In = _mm_set_ss(Value);
+    __m128 In = _mm_set_ss(Float);
     __m128 Out = _mm_rsqrt_ss(In);
     Result = _mm_cvtss_f32(Out);
 #else
-    Result = 1.0f/HMM_SquareRootF(Value);
+    Result = 1.0f/HMM_SquareRootF(Float);
 #endif
 
     return(Result);
 }
 
-HINLINE float
-HMM_LengthSquaredVec2(hmm_vec2 A)
-{
-    float Result;
-    
-    Result = HMM_DotVec2(A, A);
-    
-    return(Result);
-}
-
-HINLINE float
-HMM_LengthSquaredVec3(hmm_vec3 A)
-{
-    float Result;
-
-    Result = HMM_DotVec3(A, A);
-    
-    return (Result);
-}
-
-HINLINE float 
-HMM_LengthSquaredVec4(hmm_vec4 A)
-{
-    float Result;
-    
-    Result = HMM_DotVec4(A, A);
-    
-    return(Result);
-}
-
-HINLINE float
-HMM_LengthVec2(hmm_vec2 A)
-{
-    float Result;
-    
-    Result = HMM_SquareRootF(HMM_LengthSquaredVec2(A));
-    
-    return(Result);
-}
-
-HINLINE float
-HMM_LengthVec3(hmm_vec3 A)
-{
-    float Result;
-
-    Result = HMM_SquareRootF(HMM_LengthSquaredVec3(A));
-    
-    return (Result);
-}
-
-HINLINE float 
-HMM_LengthVec4(hmm_vec4 A)
-{
-    float Result;
-    
-    Result = HMM_SquareRootF(HMM_LengthSquaredVec4(A));
-    
-    return(Result);
-}
-
-HINLINE float
-HMM_Power(float Base, int Exponent)
+HINLINE float HMM_Power(float Base, int Exponent)
 {
     float Result = 1.0f;
     float Mul = Exponent < 0 ? 1.f / Base : Base;
@@ -944,23 +577,32 @@ HMM_Power(float Base, int Exponent)
     return (Result);
 }
 
-HINLINE float
-HMM_PowerF(float Base, float Exponent)
+HINLINE float HMM_PowerF(float Base, float Exponent)
 {
-    return HMM_EXPF(Exponent * HMM_LOGF(Base));
-}
+    float Result = HMM_EXPF(Exponent * HMM_LOGF(Base));
 
-HINLINE float
-HMM_Lerp(float A, float Time, float B)
-{
-    float Result = 0;
-
-    Result = (1.0f - Time) * A + Time * B;
     return (Result);
 }
 
-HINLINE float
-HMM_Clamp(float Min, float Value, float Max)
+
+/*
+ * Utility functions
+ */
+HINLINE float HMM_ToRadians(float Degrees)
+{
+    float Result = Degrees * (HMM_PI32 / 180.0f);
+    
+    return (Result);
+}
+
+HINLINE float HMM_Lerp(float A, float Time, float B)
+{
+    float Result = (1.0f - Time) * A + Time * B;
+
+    return (Result);
+}
+
+HINLINE float HMM_Clamp(float Min, float Value, float Max)
 {
     float Result = Value;
 
@@ -976,8 +618,443 @@ HMM_Clamp(float Min, float Value, float Max)
     return (Result);
 }
 
-HINLINE hmm_vec2
-HMM_NormalizeVec2(hmm_vec2 A)
+
+/*
+ * Vector initialization
+ */
+
+HINLINE hmm_vec2 HMM_Vec2(float X, float Y)
+{
+    hmm_vec2 Result;
+
+    Result.X = X;
+    Result.Y = Y;
+
+    return (Result);
+}
+
+HINLINE hmm_vec2 HMM_Vec2i(int X, int Y)
+{
+    hmm_vec2 Result;
+
+    Result.X = (float)X;
+    Result.Y = (float)Y;
+
+    return (Result);
+}
+
+HINLINE hmm_vec3 HMM_Vec3(float X, float Y, float Z)
+{
+    hmm_vec3 Result;
+
+    Result.X = X;
+    Result.Y = Y;
+    Result.Z = Z;
+
+    return (Result);
+}
+
+HINLINE hmm_vec3 HMM_Vec3i(int X, int Y, int Z)
+{
+    hmm_vec3 Result;
+
+    Result.X = (float)X;
+    Result.Y = (float)Y;
+    Result.Z = (float)Z;
+
+    return (Result);
+}
+
+HINLINE hmm_vec4 HMM_Vec4(float X, float Y, float Z, float W)
+{
+    hmm_vec4 Result;
+
+#ifdef HANDMADE_MATH__USE_SSE
+    Result.InternalElementsSSE = _mm_setr_ps(X, Y, Z, W);
+#else
+    Result.X = X;
+    Result.Y = Y;
+    Result.Z = Z;
+    Result.W = W;
+#endif
+
+    return (Result);
+}
+
+HINLINE hmm_vec4 HMM_Vec4i(int X, int Y, int Z, int W)
+{
+    hmm_vec4 Result;
+
+#ifdef HANDMADE_MATH__USE_SSE
+    Result.InternalElementsSSE = _mm_setr_ps((float)X, (float)Y, (float)Z, (float)W);
+#else
+    Result.X = (float)X;
+    Result.Y = (float)Y;
+    Result.Z = (float)Z;
+    Result.W = (float)W;
+#endif
+
+    return (Result);
+}
+
+HINLINE hmm_vec4 HMM_Vec4v(hmm_vec3 Vector, float W)
+{
+    hmm_vec4 Result;
+    
+#ifdef HANDMADE_MATH__USE_SSE
+    Result.InternalElementsSSE = _mm_setr_ps(Vector.X, Vector.Y, Vector.Z, W);
+#else
+    Result.XYZ = Vector;
+    Result.W = W;
+#endif
+    
+    return (Result);
+}
+
+
+/*
+ * Binary vector operations
+ */
+
+HINLINE hmm_vec2 HMM_AddVec2(hmm_vec2 Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result;
+
+    Result.X = Left.X + Right.X;
+    Result.Y = Left.Y + Right.Y;
+
+    return (Result);
+}
+
+HINLINE hmm_vec3 HMM_AddVec3(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result;
+
+    Result.X = Left.X + Right.X;
+    Result.Y = Left.Y + Right.Y;
+    Result.Z = Left.Z + Right.Z;
+
+    return (Result);
+}
+
+HINLINE hmm_vec4 HMM_AddVec4(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result;
+
+#ifdef HANDMADE_MATH__USE_SSE
+    Result.InternalElementsSSE = _mm_add_ps(Left.InternalElementsSSE, Right.InternalElementsSSE);
+#else    
+    Result.X = Left.X + Right.X;
+    Result.Y = Left.Y + Right.Y;
+    Result.Z = Left.Z + Right.Z;
+    Result.W = Left.W + Right.W;    
+#endif
+
+    return (Result);
+}
+
+HINLINE hmm_vec2 HMM_SubtractVec2(hmm_vec2 Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result;
+
+    Result.X = Left.X - Right.X;
+    Result.Y = Left.Y - Right.Y;
+
+    return (Result);
+}
+
+HINLINE hmm_vec3 HMM_SubtractVec3(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result;
+
+    Result.X = Left.X - Right.X;
+    Result.Y = Left.Y - Right.Y;
+    Result.Z = Left.Z - Right.Z;
+
+    return (Result);
+}
+
+HINLINE hmm_vec4 HMM_SubtractVec4(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result;
+    
+#ifdef HANDMADE_MATH__USE_SSE
+    Result.InternalElementsSSE = _mm_sub_ps(Left.InternalElementsSSE, Right.InternalElementsSSE);
+#else    
+    Result.X = Left.X - Right.X;
+    Result.Y = Left.Y - Right.Y;
+    Result.Z = Left.Z - Right.Z;
+    Result.W = Left.W - Right.W;    
+#endif
+
+    return (Result);
+}
+
+HINLINE hmm_vec2 HMM_MultiplyVec2(hmm_vec2 Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result;
+
+    Result.X = Left.X * Right.X;
+    Result.Y = Left.Y * Right.Y;
+
+    return (Result);
+}
+
+HINLINE hmm_vec2 HMM_MultiplyVec2f(hmm_vec2 Left, float Right)
+{
+    hmm_vec2 Result;
+
+    Result.X = Left.X * Right;
+    Result.Y = Left.Y * Right;
+
+    return (Result);
+}
+
+HINLINE hmm_vec3 HMM_MultiplyVec3(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result;
+
+    Result.X = Left.X * Right.X;
+    Result.Y = Left.Y * Right.Y;
+    Result.Z = Left.Z * Right.Z;
+
+    return (Result);
+}
+
+HINLINE hmm_vec3 HMM_MultiplyVec3f(hmm_vec3 Left, float Right)
+{
+    hmm_vec3 Result;
+
+    Result.X = Left.X * Right;
+    Result.Y = Left.Y * Right;
+    Result.Z = Left.Z * Right;
+
+    return (Result);
+}
+
+HINLINE hmm_vec4 HMM_MultiplyVec4(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result;
+
+#ifdef HANDMADE_MATH__USE_SSE
+    Result.InternalElementsSSE = _mm_mul_ps(Left.InternalElementsSSE, Right.InternalElementsSSE);
+#else
+    Result.X = Left.X * Right.X;
+    Result.Y = Left.Y * Right.Y;
+    Result.Z = Left.Z * Right.Z;
+    Result.W = Left.W * Right.W;    
+#endif
+
+    return (Result);
+}
+
+HINLINE hmm_vec4 HMM_MultiplyVec4f(hmm_vec4 Left, float Right)
+{
+    hmm_vec4 Result;
+
+#ifdef HANDMADE_MATH__USE_SSE
+    __m128 Scalar = _mm_set1_ps(Right);
+    Result.InternalElementsSSE = _mm_mul_ps(Left.InternalElementsSSE, Scalar);
+#else    
+    Result.X = Left.X * Right;
+    Result.Y = Left.Y * Right;
+    Result.Z = Left.Z * Right;
+    Result.W = Left.W * Right;
+#endif
+    
+    return (Result);
+}
+
+HINLINE hmm_vec2 HMM_DivideVec2(hmm_vec2 Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result;
+
+    Result.X = Left.X / Right.X;
+    Result.Y = Left.Y / Right.Y;
+
+    return (Result);
+}
+
+HINLINE hmm_vec2 HMM_DivideVec2f(hmm_vec2 Left, float Right)
+{
+    hmm_vec2 Result;
+
+    Result.X = Left.X / Right;
+    Result.Y = Left.Y / Right;
+
+    return (Result);
+}
+
+HINLINE hmm_vec3 HMM_DivideVec3(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result;
+
+    Result.X = Left.X / Right.X;
+    Result.Y = Left.Y / Right.Y;
+    Result.Z = Left.Z / Right.Z;
+
+    return (Result);
+}
+
+HINLINE hmm_vec3 HMM_DivideVec3f(hmm_vec3 Left, float Right)
+{
+    hmm_vec3 Result;
+
+    Result.X = Left.X / Right;
+    Result.Y = Left.Y / Right;
+    Result.Z = Left.Z / Right;
+
+    return (Result);
+}
+
+HINLINE hmm_vec4 HMM_DivideVec4(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result;
+    
+#ifdef HANDMADE_MATH__USE_SSE
+    Result.InternalElementsSSE = _mm_div_ps(Left.InternalElementsSSE, Right.InternalElementsSSE);
+#else
+    Result.X = Left.X / Right.X;
+    Result.Y = Left.Y / Right.Y;
+    Result.Z = Left.Z / Right.Z;
+    Result.W = Left.W / Right.W;
+#endif
+    
+    return (Result);
+}
+
+HINLINE hmm_vec4 HMM_DivideVec4f(hmm_vec4 Left, float Right)
+{
+    hmm_vec4 Result;
+
+#ifdef HANDMADE_MATH__USE_SSE
+    __m128 Scalar = _mm_set1_ps(Right);
+    Result.InternalElementsSSE = _mm_div_ps(Left.InternalElementsSSE, Scalar);
+#else    
+    Result.X = Left.X / Right;
+    Result.Y = Left.Y / Right;
+    Result.Z = Left.Z / Right;
+    Result.W = Left.W / Right;
+#endif
+    
+    return (Result);
+}
+
+HINLINE hmm_bool HMM_EqualsVec2(hmm_vec2 Left, hmm_vec2 Right)
+{
+    hmm_bool Result = (Left.X == Right.X && Left.Y == Right.Y);
+
+    return (Result);
+}
+
+HINLINE hmm_bool HMM_EqualsVec3(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_bool Result = (Left.X == Right.X && Left.Y == Right.Y && Left.Z == Right.Z);
+
+    return (Result);
+}
+
+HINLINE hmm_bool HMM_EqualsVec4(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_bool Result = (Left.X == Right.X && Left.Y == Right.Y && Left.Z == Right.Z && Left.W == Right.W);
+
+    return (Result);
+}
+
+HINLINE float HMM_DotVec2(hmm_vec2 VecOne, hmm_vec2 VecTwo)
+{
+    float Result = (VecOne.X * VecTwo.X) + (VecOne.Y * VecTwo.Y);
+    
+    return (Result);
+}
+
+HINLINE float HMM_DotVec3(hmm_vec3 VecOne, hmm_vec3 VecTwo)
+{
+    float Result = (VecOne.X * VecTwo.X) + (VecOne.Y * VecTwo.Y) + (VecOne.Z * VecTwo.Z);
+    
+    return (Result);
+}
+
+HINLINE float HMM_DotVec4(hmm_vec4 VecOne, hmm_vec4 VecTwo)
+{
+    float Result;
+
+    // NOTE(zak): IN the future if we wanna check what version SSE is support 
+    // we can use _mm_dp_ps (4.3) but for now we will use the old way. 
+    // Or a r = _mm_mul_ps(v1, v2), r = _mm_hadd_ps(r, r), r = _mm_hadd_ps(r, r) for SSE3
+#ifdef HANDMADE_MATH__USE_SSE
+    __m128 SSEResultOne = _mm_mul_ps(VecOne.InternalElementsSSE, VecTwo.InternalElementsSSE);
+    __m128 SSEResultTwo = _mm_shuffle_ps(SSEResultOne, SSEResultOne, _MM_SHUFFLE(2, 3, 0, 1));
+    SSEResultOne = _mm_add_ps(SSEResultOne, SSEResultTwo);
+    SSEResultTwo = _mm_shuffle_ps(SSEResultOne, SSEResultOne, _MM_SHUFFLE(0, 1, 2, 3));
+    SSEResultOne = _mm_add_ps(SSEResultOne, SSEResultTwo);       
+    _mm_store_ss(&Result, SSEResultOne);
+#else
+    Result = (VecOne.X * VecTwo.X) + (VecOne.Y * VecTwo.Y) + (VecOne.Z * VecTwo.Z) + (VecOne.W * VecTwo.W);
+#endif
+    
+    return (Result);
+}
+
+HINLINE hmm_vec3 HMM_Cross(hmm_vec3 VecOne, hmm_vec3 VecTwo)
+{
+    hmm_vec3 Result;
+
+    Result.X = (VecOne.Y * VecTwo.Z) - (VecOne.Z * VecTwo.Y);
+    Result.Y = (VecOne.Z * VecTwo.X) - (VecOne.X * VecTwo.Z);
+    Result.Z = (VecOne.X * VecTwo.Y) - (VecOne.Y * VecTwo.X);
+
+    return (Result);
+}
+
+
+/*
+ * Unary vector operations
+ */
+
+HINLINE float HMM_LengthSquaredVec2(hmm_vec2 A)
+{
+    float Result = HMM_DotVec2(A, A);
+    
+    return(Result);
+}
+
+HINLINE float HMM_LengthSquaredVec3(hmm_vec3 A)
+{
+    float Result = HMM_DotVec3(A, A);
+    
+    return (Result);
+}
+
+HINLINE float HMM_LengthSquaredVec4(hmm_vec4 A)
+{
+    float Result = HMM_DotVec4(A, A);
+    
+    return (Result);
+}
+
+HINLINE float HMM_LengthVec2(hmm_vec2 A)
+{
+    float Result = HMM_SquareRootF(HMM_LengthSquaredVec2(A));
+    
+    return (Result);
+}
+
+HINLINE float HMM_LengthVec3(hmm_vec3 A)
+{
+    float Result = HMM_SquareRootF(HMM_LengthSquaredVec3(A));
+    
+    return (Result);
+}
+
+HINLINE float HMM_LengthVec4(hmm_vec4 A)
+{
+    float Result = HMM_SquareRootF(HMM_LengthSquaredVec4(A));
+    
+    return(Result);
+}
+
+HINLINE hmm_vec2 HMM_NormalizeVec2(hmm_vec2 A)
 {
     hmm_vec2 Result = {0};
 
@@ -993,8 +1070,7 @@ HMM_NormalizeVec2(hmm_vec2 A)
     return (Result);
 }
 
-HINLINE hmm_vec3
-HMM_NormalizeVec3(hmm_vec3 A)
+HINLINE hmm_vec3 HMM_NormalizeVec3(hmm_vec3 A)
 {
     hmm_vec3 Result = {0};
 
@@ -1011,8 +1087,7 @@ HMM_NormalizeVec3(hmm_vec3 A)
     return (Result);
 }
 
-HINLINE hmm_vec4
-HMM_NormalizeVec4(hmm_vec4 A)
+HINLINE hmm_vec4 HMM_NormalizeVec4(hmm_vec4 A)
 {
     hmm_vec4 Result = {0};
 
@@ -1037,435 +1112,37 @@ HMM_NormalizeVec4(hmm_vec4 A)
     return (Result);
 }
 
-HINLINE float
-HMM_DotVec2(hmm_vec2 VecOne, hmm_vec2 VecTwo)
-{
-    float Result;
 
-    Result = (VecOne.X * VecTwo.X) + (VecOne.Y * VecTwo.Y);
+/*
+ * SSE stuff
+ */
+
+#ifdef HANDMADE_MATH__USE_SSE
+HINLINE __m128 HMM_LinearCombineSSE(__m128 Left, hmm_mat4 Right)
+{
+    __m128 Result;
+    Result = _mm_mul_ps(_mm_shuffle_ps(Left, Left, 0x00), Right.Rows[0]);
+    Result = _mm_add_ps(Result, _mm_mul_ps(_mm_shuffle_ps(Left, Left, 0x55), Right.Rows[1]));
+    Result = _mm_add_ps(Result, _mm_mul_ps(_mm_shuffle_ps(Left, Left, 0xaa), Right.Rows[2]));
+    Result = _mm_add_ps(Result, _mm_mul_ps(_mm_shuffle_ps(Left, Left, 0xff), Right.Rows[3]));
     
     return (Result);
 }
-
-HINLINE float
-HMM_DotVec3(hmm_vec3 VecOne, hmm_vec3 VecTwo)
-{
-    float Result;
-
-    Result = (VecOne.X * VecTwo.X) + (VecOne.Y * VecTwo.Y) + (VecOne.Z * VecTwo.Z);
-    
-    return (Result);
-}
-
-HINLINE float
-HMM_DotVec4(hmm_vec4 VecOne, hmm_vec4 VecTwo)
-{
-    float Result;
-
-    // NOTE(zak): IN the future if we wanna check what version SSE is support 
-    // we can use _mm_dp_ps (4.3) but for now we will use the old way. 
-    // Or a r = _mm_mul_ps(v1, v2), r = _mm_hadd_ps(r, r), r = _mm_hadd_ps(r, r) for SSE3
-#ifdef HANDMADE_MATH__USE_SSE
-    __m128 SSEResultOne = _mm_mul_ps(VecOne.InternalElementsSSE, VecTwo.InternalElementsSSE);
-    __m128 SSEResultTwo = _mm_shuffle_ps(SSEResultOne, SSEResultOne, _MM_SHUFFLE(2, 3, 0, 1));
-    SSEResultOne = _mm_add_ps(SSEResultOne, SSEResultTwo);
-    SSEResultTwo = _mm_shuffle_ps(SSEResultOne, SSEResultOne, _MM_SHUFFLE(0, 1, 2, 3));
-    SSEResultOne = _mm_add_ps(SSEResultOne, SSEResultTwo);       
-    _mm_store_ss(&Result, SSEResultOne);
-#else
-    Result = (VecOne.X * VecTwo.X) + (VecOne.Y * VecTwo.Y) + (VecOne.Z * VecTwo.Z) + (VecOne.W * VecTwo.W);
-#endif
-    
-    return (Result);
-}
-
-HINLINE hmm_vec3
-HMM_Cross(hmm_vec3 VecOne, hmm_vec3 VecTwo)
-{
-    hmm_vec3 Result;
-
-    Result.X = (VecOne.Y * VecTwo.Z) - (VecOne.Z * VecTwo.Y);
-    Result.Y = (VecOne.Z * VecTwo.X) - (VecOne.X * VecTwo.Z);
-    Result.Z = (VecOne.X * VecTwo.Y) - (VecOne.Y * VecTwo.X);
-
-    return (Result);
-}
-
-HINLINE hmm_vec2
-HMM_Vec2(float X, float Y)
-{
-    hmm_vec2 Result;
-
-    Result.X = X;
-    Result.Y = Y;
-
-    return (Result);
-}
-
-HINLINE hmm_vec2
-HMM_Vec2i(int X, int Y)
-{
-    hmm_vec2 Result;
-
-    Result.X = (float)X;
-    Result.Y = (float)Y;
-
-    return (Result);
-}
-
-HINLINE hmm_vec3
-HMM_Vec3(float X, float Y, float Z)
-{
-    hmm_vec3 Result;
-
-    Result.X = X;
-    Result.Y = Y;
-    Result.Z = Z;
-
-    return (Result);
-}
-
-HINLINE hmm_vec3
-HMM_Vec3i(int X, int Y, int Z)
-{
-    hmm_vec3 Result;
-
-    Result.X = (float)X;
-    Result.Y = (float)Y;
-    Result.Z = (float)Z;
-
-    return (Result);
-}
-
-HINLINE hmm_vec4
-HMM_Vec4(float X, float Y, float Z, float W)
-{
-    hmm_vec4 Result;
-
-#ifdef HANDMADE_MATH__USE_SSE
-    Result.InternalElementsSSE = _mm_setr_ps(X, Y, Z, W);
-#else
-    Result.X = X;
-    Result.Y = Y;
-    Result.Z = Z;
-    Result.W = W;
-#endif
-    return (Result);
-}
-
-HINLINE hmm_vec4
-HMM_Vec4i(int X, int Y, int Z, int W)
-{
-    hmm_vec4 Result;
-
-#ifdef HANDMADE_MATH__USE_SSE
-    Result.InternalElementsSSE = _mm_setr_ps((float)X, (float)Y, (float)Z, (float)W);
-#else
-    Result.X = (float)X;
-    Result.Y = (float)Y;
-    Result.Z = (float)Z;
-    Result.W = (float)W;
-#endif
-    return (Result);
-}
-
-HINLINE hmm_vec4
-HMM_Vec4v(hmm_vec3 Vector, float W)
-{
-    hmm_vec4 Result;
-    
-#ifdef HANDMADE_MATH__USE_SSE
-    Result.InternalElementsSSE = _mm_setr_ps(Vector.X, Vector.Y, Vector.Z, W);
-#else
-    Result.XYZ = Vector;
-    Result.W = W;
-#endif
-    
-    return (Result);
-}
-
-HINLINE hmm_vec2
-HMM_AddVec2(hmm_vec2 Left, hmm_vec2 Right)
-{
-    hmm_vec2 Result;
-
-    Result.X = Left.X + Right.X;
-    Result.Y = Left.Y + Right.Y;
-
-    return (Result);
-}
-
-HINLINE hmm_vec3
-HMM_AddVec3(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result;
-
-    Result.X = Left.X + Right.X;
-    Result.Y = Left.Y + Right.Y;
-    Result.Z = Left.Z + Right.Z;
-
-    return (Result);
-}
-
-HINLINE hmm_vec4
-HMM_AddVec4(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result;
-
-#ifdef HANDMADE_MATH__USE_SSE
-    Result.InternalElementsSSE = _mm_add_ps(Left.InternalElementsSSE, Right.InternalElementsSSE);
-#else    
-    Result.X = Left.X + Right.X;
-    Result.Y = Left.Y + Right.Y;
-    Result.Z = Left.Z + Right.Z;
-    Result.W = Left.W + Right.W;    
 #endif
 
-    return (Result);
-}
 
-HINLINE hmm_vec2
-HMM_SubtractVec2(hmm_vec2 Left, hmm_vec2 Right)
-{
-    hmm_vec2 Result;
+/*
+ * Matrix functions
+ */
 
-    Result.X = Left.X - Right.X;
-    Result.Y = Left.Y - Right.Y;
-
-    return (Result);
-}
-
-HINLINE hmm_vec3
-HMM_SubtractVec3(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result;
-
-    Result.X = Left.X - Right.X;
-    Result.Y = Left.Y - Right.Y;
-    Result.Z = Left.Z - Right.Z;
-
-    return (Result);
-}
-
-HINLINE hmm_vec4
-HMM_SubtractVec4(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result;
-    
-#ifdef HANDMADE_MATH__USE_SSE
-    Result.InternalElementsSSE = _mm_sub_ps(Left.InternalElementsSSE, Right.InternalElementsSSE);
-#else    
-    Result.X = Left.X - Right.X;
-    Result.Y = Left.Y - Right.Y;
-    Result.Z = Left.Z - Right.Z;
-    Result.W = Left.W - Right.W;    
-#endif
-
-    return (Result);
-}
-
-HINLINE hmm_vec2
-HMM_MultiplyVec2(hmm_vec2 Left, hmm_vec2 Right)
-{
-    hmm_vec2 Result;
-
-    Result.X = Left.X * Right.X;
-    Result.Y = Left.Y * Right.Y;
-
-    return (Result);
-}
-
-HINLINE hmm_vec2
-HMM_MultiplyVec2f(hmm_vec2 Left, float Right)
-{
-    hmm_vec2 Result;
-
-    Result.X = Left.X * Right;
-    Result.Y = Left.Y * Right;
-
-    return (Result);
-}
-
-HINLINE hmm_vec3
-HMM_MultiplyVec3(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result;
-
-    Result.X = Left.X * Right.X;
-    Result.Y = Left.Y * Right.Y;
-    Result.Z = Left.Z * Right.Z;
-
-    return (Result);
-}
-
-HINLINE hmm_vec3
-HMM_MultiplyVec3f(hmm_vec3 Left, float Right)
-{
-    hmm_vec3 Result;
-
-    Result.X = Left.X * Right;
-    Result.Y = Left.Y * Right;
-    Result.Z = Left.Z * Right;
-
-    return (Result);
-}
-
-HINLINE hmm_vec4
-HMM_MultiplyVec4(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result;
-
-#ifdef HANDMADE_MATH__USE_SSE
-    Result.InternalElementsSSE = _mm_mul_ps(Left.InternalElementsSSE, Right.InternalElementsSSE);
-#else
-    Result.X = Left.X * Right.X;
-    Result.Y = Left.Y * Right.Y;
-    Result.Z = Left.Z * Right.Z;
-    Result.W = Left.W * Right.W;    
-#endif
-
-    return (Result);
-}
-
-HINLINE hmm_vec4
-HMM_MultiplyVec4f(hmm_vec4 Left, float Right)
-{
-    hmm_vec4 Result;
-
-#ifdef HANDMADE_MATH__USE_SSE
-    __m128 Scalar = _mm_set1_ps(Right);
-    Result.InternalElementsSSE = _mm_mul_ps(Left.InternalElementsSSE, Scalar);
-#else    
-    Result.X = Left.X * Right;
-    Result.Y = Left.Y * Right;
-    Result.Z = Left.Z * Right;
-    Result.W = Left.W * Right;
-#endif
-    
-    return (Result);
-}
-
-HINLINE hmm_vec2
-HMM_DivideVec2(hmm_vec2 Left, hmm_vec2 Right)
-{
-    hmm_vec2 Result;
-
-    Result.X = Left.X / Right.X;
-    Result.Y = Left.Y / Right.Y;
-
-    return (Result);
-}
-
-HINLINE hmm_vec2
-HMM_DivideVec2f(hmm_vec2 Left, float Right)
-{
-    hmm_vec2 Result;
-
-    Result.X = Left.X / Right;
-    Result.Y = Left.Y / Right;
-
-    return (Result);
-}
-
-HINLINE hmm_vec3
-HMM_DivideVec3(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result;
-
-    Result.X = Left.X / Right.X;
-    Result.Y = Left.Y / Right.Y;
-    Result.Z = Left.Z / Right.Z;
-
-    return (Result);
-}
-
-HINLINE hmm_vec3
-HMM_DivideVec3f(hmm_vec3 Left, float Right)
-{
-    hmm_vec3 Result;
-
-    Result.X = Left.X / Right;
-    Result.Y = Left.Y / Right;
-    Result.Z = Left.Z / Right;
-
-    return (Result);
-}
-
-HINLINE hmm_vec4
-HMM_DivideVec4(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result;
-    
-#ifdef HANDMADE_MATH__USE_SSE
-    Result.InternalElementsSSE = _mm_div_ps(Left.InternalElementsSSE, Right.InternalElementsSSE);
-#else
-    Result.X = Left.X / Right.X;
-    Result.Y = Left.Y / Right.Y;
-    Result.Z = Left.Z / Right.Z;
-    Result.W = Left.W / Right.W;
-#endif
-    
-    return (Result);
-}
-
-HINLINE hmm_vec4
-HMM_DivideVec4f(hmm_vec4 Left, float Right)
-{
-    hmm_vec4 Result;
-
-#ifdef HANDMADE_MATH__USE_SSE
-    __m128 Scalar = _mm_set1_ps(Right);
-    Result.InternalElementsSSE = _mm_div_ps(Left.InternalElementsSSE, Scalar);
-#else    
-    Result.X = Left.X / Right;
-    Result.Y = Left.Y / Right;
-    Result.Z = Left.Z / Right;
-    Result.W = Left.W / Right;
-#endif
-    
-    return (Result);
-}
-
-HINLINE hmm_bool
-HMM_EqualsVec2(hmm_vec2 Left, hmm_vec2 Right)
-{
-    hmm_bool Result;
-
-    Result = (Left.X == Right.X && Left.Y == Right.Y);
-
-    return (Result);
-}
-
-HINLINE hmm_bool
-HMM_EqualsVec3(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_bool Result;
-
-    Result = (Left.X == Right.X && Left.Y == Right.Y && Left.Z == Right.Z);
-
-    return (Result);
-}
-
-HINLINE hmm_bool
-HMM_EqualsVec4(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_bool Result;
-
-    Result = (Left.X == Right.X && Left.Y == Right.Y && Left.Z == Right.Z && Left.W == Right.W);
-
-    return (Result);
-}
-
-HINLINE hmm_mat4
-HMM_Mat4(void)
+HINLINE hmm_mat4 HMM_Mat4(void)
 {
     hmm_mat4 Result = {0};
 
     return (Result);
 }
 
-HINLINE hmm_mat4
-HMM_Mat4d(float Diagonal)
+HINLINE hmm_mat4 HMM_Mat4d(float Diagonal)
 {
     hmm_mat4 Result = HMM_Mat4();
     
@@ -1477,8 +1154,30 @@ HMM_Mat4d(float Diagonal)
     return (Result);
 }
 
-HINLINE hmm_mat4
-HMM_AddMat4(hmm_mat4 Left, hmm_mat4 Right)
+HINLINE hmm_mat4 HMM_Transpose(hmm_mat4 Matrix)
+{
+    hmm_mat4 Result;
+
+#ifdef HANDMADE_MATH__USE_SSE
+    Result = Matrix;
+    
+    _MM_TRANSPOSE4_PS(Result.Rows[0], Result.Rows[1], Result.Rows[2], Result.Rows[3]);
+#else
+    int Columns;
+    for(Columns = 0; Columns < 4; ++Columns)
+    {
+        int Rows;
+        for(Rows = 0; Rows < 4; ++Rows)
+        {
+            Result.Elements[Rows][Columns] = Matrix.Elements[Columns][Rows];
+        }
+    }
+#endif
+
+    return (Result);
+}
+
+HINLINE hmm_mat4 HMM_AddMat4(hmm_mat4 Left, hmm_mat4 Right)
 {
     hmm_mat4 Result;
 
@@ -1498,11 +1197,11 @@ HMM_AddMat4(hmm_mat4 Left, hmm_mat4 Right)
         }
     }
 #endif
+
     return (Result);
 }
 
-HINLINE hmm_mat4
-HMM_SubtractMat4(hmm_mat4 Left, hmm_mat4 Right)
+HINLINE hmm_mat4 HMM_SubtractMat4(hmm_mat4 Left, hmm_mat4 Right)
 {
     hmm_mat4 Result;
 
@@ -1522,30 +1221,15 @@ HMM_SubtractMat4(hmm_mat4 Left, hmm_mat4 Right)
         }
     }
 #endif
+
     return (Result);
 }
 
-#ifdef HANDMADE_MATH__USE_SSE
-HINLINE __m128
-HMM_LinearCombineSSE(__m128 Left, hmm_mat4 Right)
-{
-    __m128 Result;
-    Result = _mm_mul_ps(_mm_shuffle_ps(Left, Left, 0x00), Right.Rows[0]);
-    Result = _mm_add_ps(Result, _mm_mul_ps(_mm_shuffle_ps(Left, Left, 0x55), Right.Rows[1]));
-    Result = _mm_add_ps(Result, _mm_mul_ps(_mm_shuffle_ps(Left, Left, 0xaa), Right.Rows[2]));
-    Result = _mm_add_ps(Result, _mm_mul_ps(_mm_shuffle_ps(Left, Left, 0xff), Right.Rows[3]));
-    
-    return(Result);
-}
-#endif
-
-HINLINE hmm_mat4
-HMM_MultiplyMat4(hmm_mat4 Left, hmm_mat4 Right)
+HINLINE hmm_mat4 HMM_MultiplyMat4(hmm_mat4 Left, hmm_mat4 Right)
 {
     hmm_mat4 Result;
 
 #ifdef HANDMADE_MATH__USE_SSE
-    
     hmm_mat4 TransposedLeft = HMM_Transpose(Left);
     hmm_mat4 TransposedRight = HMM_Transpose(Right);
 
@@ -1555,7 +1239,6 @@ HMM_MultiplyMat4(hmm_mat4 Left, hmm_mat4 Right)
     Result.Rows[3] = HMM_LinearCombineSSE(TransposedLeft.Rows[3], TransposedRight);       
     
     Result = HMM_Transpose(Result);
-    
 #else
     int Columns;
     for(Columns = 0; Columns < 4; ++Columns)
@@ -1573,12 +1256,12 @@ HMM_MultiplyMat4(hmm_mat4 Left, hmm_mat4 Right)
             Result.Elements[Columns][Rows] = Sum;
         }
     }
-#endif 
+#endif
+
     return (Result);
 }
 
-HINLINE hmm_mat4
-HMM_MultiplyMat4f(hmm_mat4 Matrix, float Scalar)
+HINLINE hmm_mat4 HMM_MultiplyMat4f(hmm_mat4 Matrix, float Scalar)
 {
     hmm_mat4 Result;
     
@@ -1599,11 +1282,11 @@ HMM_MultiplyMat4f(hmm_mat4 Matrix, float Scalar)
         }
     }
 #endif
+
     return (Result);
 }
 
-HINLINE hmm_vec4
-HMM_MultiplyMat4ByVec4(hmm_mat4 Matrix, hmm_vec4 Vector)
+HINLINE hmm_vec4 HMM_MultiplyMat4ByVec4(hmm_mat4 Matrix, hmm_vec4 Vector)
 {
     hmm_vec4 Result;
     
@@ -1622,8 +1305,7 @@ HMM_MultiplyMat4ByVec4(hmm_mat4 Matrix, hmm_vec4 Vector)
     return (Result);
 }
 
-HINLINE hmm_mat4
-HMM_DivideMat4f(hmm_mat4 Matrix, float Scalar)
+HINLINE hmm_mat4 HMM_DivideMat4f(hmm_mat4 Matrix, float Scalar)
 {
     hmm_mat4 Result;
     
@@ -1644,41 +1326,23 @@ HMM_DivideMat4f(hmm_mat4 Matrix, float Scalar)
         }
     }
 #endif
+
     return (Result);
 }
 
-HINLINE hmm_mat4
-HMM_Transpose(hmm_mat4 Matrix)
-{
-    hmm_mat4 Result;
 
-#ifdef HANDMADE_MATH__USE_SSE
-    Result = Matrix;
-    
-    _MM_TRANSPOSE4_PS(Result.Rows[0], Result.Rows[1], Result.Rows[2], Result.Rows[3]);    
-#else 
-    int Columns;
-    for(Columns = 0; Columns < 4; ++Columns)
-    {
-        int Rows;
-        for(Rows = 0; Rows < 4; ++Rows)
-        {
-            Result.Elements[Rows][Columns] = Matrix.Elements[Columns][Rows];
-        }
-    }
-#endif 
-        
-    return (Result);
-}
+/*
+ * Common graphics transformations
+ */
 
-HINLINE hmm_mat4
-HMM_Orthographic(float Left, float Right, float Bottom, float Top, float Near, float Far)
+HINLINE hmm_mat4 HMM_Orthographic(float Left, float Right, float Bottom, float Top, float Near, float Far)
 {
-    hmm_mat4 Result = HMM_Mat4d(1.0f);
+    hmm_mat4 Result = HMM_Mat4();
 
     Result.Elements[0][0] = 2.0f / (Right - Left);
     Result.Elements[1][1] = 2.0f / (Top - Bottom);
     Result.Elements[2][2] = 2.0f / (Near - Far);
+    Result.Elements[3][3] = 1.0f;
 
     Result.Elements[3][0] = (Left + Right) / (Left - Right);
     Result.Elements[3][1] = (Bottom + Top) / (Bottom - Top);
@@ -1687,10 +1351,9 @@ HMM_Orthographic(float Left, float Right, float Bottom, float Top, float Near, f
     return (Result);
 }
 
-HINLINE hmm_mat4
-HMM_Perspective(float FOV, float AspectRatio, float Near, float Far)
+HINLINE hmm_mat4 HMM_Perspective(float FOV, float AspectRatio, float Near, float Far)
 {
-    hmm_mat4 Result = HMM_Mat4d(1.0f);
+    hmm_mat4 Result = HMM_Mat4();
 
     float TanThetaOver2 = HMM_TanF(FOV * (HMM_PI32 / 360.0f));
     
@@ -1704,8 +1367,7 @@ HMM_Perspective(float FOV, float AspectRatio, float Near, float Far)
     return (Result);
 }
 
-HINLINE hmm_mat4
-HMM_Translate(hmm_vec3 Translation)
+HINLINE hmm_mat4 HMM_Translate(hmm_vec3 Translation)
 {
     hmm_mat4 Result = HMM_Mat4d(1.0f);
 
@@ -1716,8 +1378,884 @@ HMM_Translate(hmm_vec3 Translation)
     return (Result);
 }
 
-HINLINE hmm_mat4
-HMM_Rotate(float Angle, hmm_vec3 Axis)
+HEXTERN hmm_mat4 HMM_Rotate(float Angle, hmm_vec3 Axis);
+
+HINLINE hmm_mat4 HMM_Scale(hmm_vec3 Scale)
+{
+    hmm_mat4 Result = HMM_Mat4d(1.0f);
+
+    Result.Elements[0][0] = Scale.X;
+    Result.Elements[1][1] = Scale.Y;
+    Result.Elements[2][2] = Scale.Z;
+
+    return (Result);
+}
+
+HEXTERN hmm_mat4 HMM_LookAt(hmm_vec3 Eye, hmm_vec3 Center, hmm_vec3 Up);
+
+
+/*
+ * Quaternion operations
+ */
+
+HINLINE hmm_quaternion HMM_Quaternion(float X, float Y, float Z, float W)
+{
+    hmm_quaternion Result;
+
+    Result.X = X;
+    Result.Y = Y;
+    Result.Z = Z;
+    Result.W = W;
+
+    return (Result);
+}
+
+HINLINE hmm_quaternion HMM_QuaternionV4(hmm_vec4 Vector)
+{
+    hmm_quaternion Result;
+
+    Result.X = Vector.X;
+    Result.Y = Vector.Y;
+    Result.Z = Vector.Z;
+    Result.W = Vector.W;
+
+    return (Result);
+}
+
+HINLINE hmm_quaternion HMM_AddQuaternion(hmm_quaternion Left, hmm_quaternion Right)
+{
+    hmm_quaternion Result;
+
+    Result.X = Left.X + Right.X;
+    Result.Y = Left.Y + Right.Y;
+    Result.Z = Left.Z + Right.Z;
+    Result.W = Left.W + Right.W;
+
+    return (Result);
+}
+
+HINLINE hmm_quaternion HMM_SubtractQuaternion(hmm_quaternion Left, hmm_quaternion Right)
+{
+    hmm_quaternion Result;
+
+    Result.X = Left.X - Right.X;
+    Result.Y = Left.Y - Right.Y;
+    Result.Z = Left.Z - Right.Z;
+    Result.W = Left.W - Right.W;
+
+    return (Result);
+}
+
+HINLINE hmm_quaternion HMM_MultiplyQuaternion(hmm_quaternion Left, hmm_quaternion Right)
+{
+    hmm_quaternion Result;
+
+    Result.X = (Left.X * Right.W) + (Left.Y * Right.Z) - (Left.Z * Right.Y) + (Left.W * Right.X);
+    Result.Y = (-Left.X * Right.Z) + (Left.Y * Right.W) + (Left.Z * Right.X) + (Left.W * Right.Y);
+    Result.Z = (Left.X * Right.Y) - (Left.Y * Right.X) + (Left.Z * Right.W) + (Left.W * Right.Z);
+    Result.W = (-Left.X * Right.X) - (Left.Y * Right.Y) - (Left.Z * Right.Z) + (Left.W * Right.W);
+
+    return (Result);
+}
+
+HINLINE hmm_quaternion HMM_MultiplyQuaternionF(hmm_quaternion Left, float Multiplicative)
+{
+    hmm_quaternion Result;
+
+    Result.X = Left.X * Multiplicative;
+    Result.Y = Left.Y * Multiplicative;
+    Result.Z = Left.Z * Multiplicative;
+    Result.W = Left.W * Multiplicative;
+
+    return (Result);
+}
+
+HINLINE hmm_quaternion HMM_DivideQuaternionF(hmm_quaternion Left, float Dividend)
+{
+    hmm_quaternion Result;
+
+    Result.X = Left.X / Dividend;
+    Result.Y = Left.Y / Dividend;
+    Result.Z = Left.Z / Dividend;
+    Result.W = Left.W / Dividend;
+
+    return (Result);
+}
+
+HEXTERN hmm_quaternion HMM_InverseQuaternion(hmm_quaternion Left);
+
+HINLINE float HMM_DotQuaternion(hmm_quaternion Left, hmm_quaternion Right)
+{
+    float Result = (Left.X * Right.X) + (Left.Y * Right.Y) + (Left.Z * Right.Z) + (Left.W * Right.W);
+
+    return (Result);
+}
+
+HINLINE hmm_quaternion HMM_NormalizeQuaternion(hmm_quaternion Left)
+{
+    hmm_quaternion Result;
+
+    float Length = HMM_SquareRootF(HMM_DotQuaternion(Left, Left));
+    Result = HMM_DivideQuaternionF(Left, Length);
+
+    return (Result);
+}
+
+HINLINE hmm_quaternion HMM_NLerp(hmm_quaternion Left, float Time, hmm_quaternion Right)
+{
+    hmm_quaternion Result;
+
+    Result.X = HMM_Lerp(Left.X, Time, Right.X);
+    Result.Y = HMM_Lerp(Left.Y, Time, Right.Y);
+    Result.Z = HMM_Lerp(Left.Z, Time, Right.Z);
+    Result.W = HMM_Lerp(Left.W, Time, Right.W);
+
+    Result = HMM_NormalizeQuaternion(Result);
+
+    return (Result);
+}
+
+HEXTERN hmm_quaternion HMM_Slerp(hmm_quaternion Left, float Time, hmm_quaternion Right);
+HEXTERN hmm_mat4 HMM_QuaternionToMat4(hmm_quaternion Left);
+HEXTERN hmm_quaternion HMM_QuaternionFromAxisAngle(hmm_vec3 Axis, float AngleOfRotation);
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+
+HINLINE float HMM_Length(hmm_vec2 A)
+{
+    float Result = HMM_LengthVec2(A);
+    
+    return (Result);
+}
+
+HINLINE float HMM_Length(hmm_vec3 A)
+{
+    float Result = HMM_LengthVec3(A);
+    
+    return (Result);
+}
+
+HINLINE float HMM_Length(hmm_vec4 A)
+{
+    float Result = HMM_LengthVec4(A);
+    
+    return (Result);
+}
+
+HINLINE float HMM_LengthSquared(hmm_vec2 A)
+{
+    float Result = HMM_LengthSquaredVec2(A);
+    
+    return (Result);
+}
+
+HINLINE float HMM_LengthSquared(hmm_vec3 A)
+{
+    float Result = HMM_LengthSquaredVec3(A);
+    
+    return (Result);
+}
+
+HINLINE float HMM_LengthSquared(hmm_vec4 A)
+{
+    float Result = HMM_LengthSquaredVec4(A);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec2 HMM_Normalize(hmm_vec2 A)
+{
+    hmm_vec2 Result = HMM_NormalizeVec2(A);    
+    
+    return (Result);
+}
+
+HINLINE hmm_vec3 HMM_Normalize(hmm_vec3 A)
+{
+    hmm_vec3 Result = HMM_NormalizeVec3(A);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec4 HMM_Normalize(hmm_vec4 A)
+{
+    hmm_vec4 Result = HMM_NormalizeVec4(A);
+    
+    return (Result);
+}
+
+HINLINE hmm_quaternion HMM_Normalize(hmm_quaternion A)
+{
+    hmm_quaternion Result = HMM_NormalizeQuaternion(A);
+
+    return (Result);
+}
+
+HINLINE float HMM_Dot(hmm_vec2 VecOne, hmm_vec2 VecTwo)
+{
+    float Result = HMM_DotVec2(VecOne, VecTwo);
+    
+    return (Result);
+}
+
+HINLINE float HMM_Dot(hmm_vec3 VecOne, hmm_vec3 VecTwo)
+{
+    float Result = HMM_DotVec3(VecOne, VecTwo);
+    
+    return (Result);
+}
+
+HINLINE float HMM_Dot(hmm_vec4 VecOne, hmm_vec4 VecTwo)
+{
+    float Result = HMM_DotVec4(VecOne, VecTwo);
+    
+    return (Result);
+}
+
+HINLINE float HMM_Dot(hmm_quaternion QuatOne, hmm_quaternion QuatTwo)
+{
+    float Result = HMM_DotQuaternion(QuatOne, QuatTwo);
+
+    return (Result);
+}
+
+HINLINE hmm_vec2 HMM_Add(hmm_vec2 Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result = HMM_AddVec2(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec3 HMM_Add(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result = HMM_AddVec3(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec4 HMM_Add(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result = HMM_AddVec4(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_mat4 HMM_Add(hmm_mat4 Left, hmm_mat4 Right)
+{
+    hmm_mat4 Result = HMM_AddMat4(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_quaternion HMM_Add(hmm_quaternion Left, hmm_quaternion Right)
+{
+    hmm_quaternion Result = HMM_AddQuaternion(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec2 HMM_Subtract(hmm_vec2 Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result = HMM_SubtractVec2(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec3 HMM_Subtract(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result = HMM_SubtractVec3(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec4 HMM_Subtract(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result = HMM_SubtractVec4(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_mat4 HMM_Subtract(hmm_mat4 Left, hmm_mat4 Right)
+{
+    hmm_mat4 Result = HMM_SubtractMat4(Left, Right);
+        
+    return (Result);
+}
+
+HINLINE hmm_quaternion HMM_Subtract(hmm_quaternion Left, hmm_quaternion Right)
+{
+    hmm_quaternion Result = HMM_SubtractQuaternion(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec2 HMM_Multiply(hmm_vec2 Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result = HMM_MultiplyVec2(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec2 HMM_Multiply(hmm_vec2 Left, float Right)
+{
+    hmm_vec2 Result = HMM_MultiplyVec2f(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec3 HMM_Multiply(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result = HMM_MultiplyVec3(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec3 HMM_Multiply(hmm_vec3 Left, float Right)
+{
+    hmm_vec3 Result = HMM_MultiplyVec3f(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec4 HMM_Multiply(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result = HMM_MultiplyVec4(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec4 HMM_Multiply(hmm_vec4 Left, float Right)
+{
+    hmm_vec4 Result = HMM_MultiplyVec4f(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_mat4 HMM_Multiply(hmm_mat4 Left, hmm_mat4 Right)
+{
+    hmm_mat4 Result = HMM_MultiplyMat4(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_mat4 HMM_Multiply(hmm_mat4 Left, float Right)
+{
+    hmm_mat4 Result = HMM_MultiplyMat4f(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec4 HMM_Multiply(hmm_mat4 Matrix, hmm_vec4 Vector)
+{
+    hmm_vec4 Result = HMM_MultiplyMat4ByVec4(Matrix, Vector);
+    
+    return (Result);
+}
+
+HINLINE hmm_quaternion HMM_Multiply(hmm_quaternion Left, hmm_quaternion Right)
+{
+    hmm_quaternion Result = HMM_MultiplyQuaternion(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_quaternion HMM_Multiply(hmm_quaternion Left, float Right)
+{
+    hmm_quaternion Result = HMM_MultiplyQuaternionF(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec2 HMM_Divide(hmm_vec2 Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result = HMM_DivideVec2(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec2 HMM_Divide(hmm_vec2 Left, float Right)
+{
+    hmm_vec2 Result = HMM_DivideVec2f(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec3 HMM_Divide(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result = HMM_DivideVec3(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec3 HMM_Divide(hmm_vec3 Left, float Right)
+{
+    hmm_vec3 Result = HMM_DivideVec3f(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec4 HMM_Divide(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result = HMM_DivideVec4(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec4 HMM_Divide(hmm_vec4 Left, float Right)
+{
+    hmm_vec4 Result = HMM_DivideVec4f(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_mat4 HMM_Divide(hmm_mat4 Left, float Right)
+{
+    hmm_mat4 Result = HMM_DivideMat4f(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_quaternion HMM_Divide(hmm_quaternion Left, float Right)
+{
+    hmm_quaternion Result = HMM_DivideQuaternionF(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_bool HMM_Equals(hmm_vec2 Left, hmm_vec2 Right)
+{
+    hmm_bool Result = HMM_EqualsVec2(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_bool HMM_Equals(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_bool Result = HMM_EqualsVec3(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_bool HMM_Equals(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_bool Result = HMM_EqualsVec4(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec2 operator+(hmm_vec2 Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result = HMM_AddVec2(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec3 operator+(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result = HMM_AddVec3(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec4 operator+(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result = HMM_AddVec4(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_mat4 operator+(hmm_mat4 Left, hmm_mat4 Right)
+{
+    hmm_mat4 Result = HMM_AddMat4(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_quaternion operator+(hmm_quaternion Left, hmm_quaternion Right)
+{
+    hmm_quaternion Result = HMM_AddQuaternion(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec2 operator-(hmm_vec2 Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result = HMM_SubtractVec2(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec3 operator-(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result = HMM_SubtractVec3(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec4 operator-(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result = HMM_SubtractVec4(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_mat4 operator-(hmm_mat4 Left, hmm_mat4 Right)
+{
+    hmm_mat4 Result = HMM_SubtractMat4(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_quaternion operator-(hmm_quaternion Left, hmm_quaternion Right)
+{
+    hmm_quaternion Result = HMM_SubtractQuaternion(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec2 operator*(hmm_vec2 Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result = HMM_MultiplyVec2(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec3 operator*(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result = HMM_MultiplyVec3(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec4 operator*(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result = HMM_MultiplyVec4(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_mat4 operator*(hmm_mat4 Left, hmm_mat4 Right)
+{
+    hmm_mat4 Result = HMM_MultiplyMat4(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_quaternion operator*(hmm_quaternion Left, hmm_quaternion Right)
+{
+    hmm_quaternion Result = HMM_MultiplyQuaternion(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec2 operator*(hmm_vec2 Left, float Right)
+{
+    hmm_vec2 Result = HMM_MultiplyVec2f(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec3 operator*(hmm_vec3 Left, float Right)
+{
+    hmm_vec3 Result = HMM_MultiplyVec3f(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec4 operator*(hmm_vec4 Left, float Right)
+{
+    hmm_vec4 Result = HMM_MultiplyVec4f(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_mat4 operator*(hmm_mat4 Left, float Right)
+{
+    hmm_mat4 Result = HMM_MultiplyMat4f(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_quaternion operator*(hmm_quaternion Left, float Right)
+{
+    hmm_quaternion Result = HMM_MultiplyQuaternionF(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec2 operator*(float Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result = HMM_MultiplyVec2f(Right, Left);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec3 operator*(float Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result = HMM_MultiplyVec3f(Right, Left);
+
+    return (Result);
+}
+
+HINLINE hmm_vec4 operator*(float Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result = HMM_MultiplyVec4f(Right, Left);
+
+    return (Result);
+}
+
+HINLINE hmm_mat4 operator*(float Left, hmm_mat4 Right)
+{
+    hmm_mat4 Result = HMM_MultiplyMat4f(Right, Left);
+
+    return (Result);
+}
+
+HINLINE hmm_quaternion operator*(float Left, hmm_quaternion Right)
+{
+    hmm_quaternion Result = HMM_MultiplyQuaternionF(Right, Left);
+
+    return (Result);
+}
+
+HINLINE hmm_vec4 operator*(hmm_mat4 Matrix, hmm_vec4 Vector)
+{
+    hmm_vec4 Result = HMM_MultiplyMat4ByVec4(Matrix, Vector);
+
+    return (Result);
+}
+
+HINLINE hmm_vec2 operator/(hmm_vec2 Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result = HMM_DivideVec2(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec3 operator/(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result = HMM_DivideVec3(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec4 operator/(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result = HMM_DivideVec4(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec2 operator/(hmm_vec2 Left, float Right)
+{
+    hmm_vec2 Result = HMM_DivideVec2f(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec3 operator/(hmm_vec3 Left, float Right)
+{
+    hmm_vec3 Result = HMM_DivideVec3f(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec4 operator/(hmm_vec4 Left, float Right)
+{
+    hmm_vec4 Result = HMM_DivideVec4f(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_mat4 operator/(hmm_mat4 Left, float Right)
+{
+    hmm_mat4 Result = HMM_DivideMat4f(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_quaternion operator/(hmm_quaternion Left, float Right)
+{
+    hmm_quaternion Result = HMM_DivideQuaternionF(Left, Right);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec2 &operator+=(hmm_vec2 &Left, hmm_vec2 Right)
+{
+    return (Left = Left + Right);
+}
+
+HINLINE hmm_vec3 &operator+=(hmm_vec3 &Left, hmm_vec3 Right)
+{
+    return (Left = Left + Right);
+}
+
+HINLINE hmm_vec4 &operator+=(hmm_vec4 &Left, hmm_vec4 Right)
+{
+    return (Left = Left + Right);
+}
+
+HINLINE hmm_mat4 &operator+=(hmm_mat4 &Left, hmm_mat4 Right)
+{
+    return (Left = Left + Right);
+}
+
+HINLINE hmm_quaternion &operator+=(hmm_quaternion &Left, hmm_quaternion Right)
+{
+    return (Left = Left + Right);
+}
+
+HINLINE hmm_vec2 &operator-=(hmm_vec2 &Left, hmm_vec2 Right)
+{
+    return (Left = Left - Right);
+}
+
+HINLINE hmm_vec3 &operator-=(hmm_vec3 &Left, hmm_vec3 Right)
+{
+    return (Left = Left - Right);
+}
+
+HINLINE hmm_vec4 &operator-=(hmm_vec4 &Left, hmm_vec4 Right)
+{
+    return (Left = Left - Right);
+}
+
+HINLINE hmm_mat4 &operator-=(hmm_mat4 &Left, hmm_mat4 Right)
+{
+    return (Left = Left - Right);
+}
+
+HINLINE hmm_quaternion &operator-=(hmm_quaternion &Left, hmm_quaternion Right)
+{
+    return (Left = Left - Right);
+}
+
+HINLINE hmm_vec2 &operator*=(hmm_vec2 &Left, hmm_vec2 Right)
+{
+    return (Left = Left * Right);
+}
+
+HINLINE hmm_vec3 &operator*=(hmm_vec3 &Left, hmm_vec3 Right)
+{
+    return (Left = Left * Right);
+}
+
+HINLINE hmm_vec4 &operator*=(hmm_vec4 &Left, hmm_vec4 Right)
+{
+    return (Left = Left * Right);
+}
+
+HINLINE hmm_vec2 &operator*=(hmm_vec2 &Left, float Right)
+{
+    return (Left = Left * Right);
+}
+
+HINLINE hmm_vec3 &operator*=(hmm_vec3 &Left, float Right)
+{
+    return (Left = Left * Right);
+}
+
+HINLINE hmm_vec4 &operator*=(hmm_vec4 &Left, float Right)
+{
+    return (Left = Left * Right);
+}
+
+HINLINE hmm_mat4 &operator*=(hmm_mat4 &Left, float Right)
+{
+    return (Left = Left * Right);
+}
+
+HINLINE hmm_quaternion &operator*=(hmm_quaternion &Left, float Right)
+{
+    return (Left = Left * Right);
+}
+
+HINLINE hmm_vec2 &operator/=(hmm_vec2 &Left, hmm_vec2 Right)
+{
+    return (Left = Left / Right);
+}
+
+HINLINE hmm_vec3 &operator/=(hmm_vec3 &Left, hmm_vec3 Right)
+{
+    return (Left = Left / Right);
+}
+
+HINLINE hmm_vec4 &operator/=(hmm_vec4 &Left, hmm_vec4 Right)
+{
+    return (Left = Left / Right);
+}
+
+HINLINE hmm_vec2 &operator/=(hmm_vec2 &Left, float Right)
+{
+    return (Left = Left / Right);
+}
+
+HINLINE hmm_vec3 &operator/=(hmm_vec3 &Left, float Right)
+{
+    return (Left = Left / Right);
+}
+
+HINLINE hmm_vec4 &operator/=(hmm_vec4 &Left, float Right)
+{
+    return (Left = Left / Right);
+}
+
+HINLINE hmm_mat4 &operator/=(hmm_mat4 &Left, float Right)
+{
+    return (Left = Left / Right);
+}
+
+HINLINE hmm_quaternion &operator/=(hmm_quaternion &Left, float Right)
+{
+    return (Left = Left / Right);
+}
+
+HINLINE hmm_bool operator==(hmm_vec2 Left, hmm_vec2 Right)
+{
+    return HMM_EqualsVec2(Left, Right);
+}
+
+HINLINE hmm_bool operator==(hmm_vec3 Left, hmm_vec3 Right)
+{
+    return HMM_EqualsVec3(Left, Right);
+}
+
+HINLINE hmm_bool operator==(hmm_vec4 Left, hmm_vec4 Right)
+{
+    return HMM_EqualsVec4(Left, Right);
+}
+
+HINLINE hmm_bool operator!=(hmm_vec2 Left, hmm_vec2 Right)
+{
+    return !HMM_EqualsVec2(Left, Right);
+}
+
+HINLINE hmm_bool operator!=(hmm_vec3 Left, hmm_vec3 Right)
+{
+    return !HMM_EqualsVec3(Left, Right);
+}
+
+HINLINE hmm_bool operator!=(hmm_vec4 Left, hmm_vec4 Right)
+{
+    return !HMM_EqualsVec4(Left, Right);
+}
+
+#endif /* __cplusplus */
+
+#ifdef __clang__
+#pragma GCC diagnostic pop
+#endif
+
+#endif /* HANDMADE_MATH_H */
+
+#ifdef HANDMADE_MATH_IMPLEMENTATION
+
+hmm_mat4 HMM_Rotate(float Angle, hmm_vec3 Axis)
 {
     hmm_mat4 Result = HMM_Mat4d(1.0f);
     
@@ -1742,20 +2280,7 @@ HMM_Rotate(float Angle, hmm_vec3 Axis)
     return (Result);
 }
 
-HINLINE hmm_mat4
-HMM_Scale(hmm_vec3 Scale)
-{
-    hmm_mat4 Result = HMM_Mat4d(1.0f);
-
-    Result.Elements[0][0] = Scale.X;
-    Result.Elements[1][1] = Scale.Y;
-    Result.Elements[2][2] = Scale.Z;
-
-    return (Result);
-}
-
-HINLINE hmm_mat4
-HMM_LookAt(hmm_vec3 Eye, hmm_vec3 Center, hmm_vec3 Up)
+hmm_mat4 HMM_LookAt(hmm_vec3 Eye, hmm_vec3 Center, hmm_vec3 Up)
 {
     hmm_mat4 Result;
 
@@ -1783,100 +2308,7 @@ HMM_LookAt(hmm_vec3 Eye, hmm_vec3 Center, hmm_vec3 Up)
     return (Result);
 }
 
-
-HINLINE hmm_quaternion 
-HMM_Quaternion(float X, float Y, float Z, float W)
-{
-    hmm_quaternion Result;
-    
-    Result.X = X;
-    Result.Y = Y;
-    Result.Z = Z;
-    Result.W = W;
-    
-    return(Result);
-}
-
-HINLINE hmm_quaternion 
-HMM_QuaternionV4(hmm_vec4 Vector)
-{
-    hmm_quaternion Result;
-    
-    Result.X = Vector.X;
-    Result.Y = Vector.Y;
-    Result.Z = Vector.Z;
-    Result.W = Vector.W;
-    
-    return(Result);    
-}
-
-HINLINE hmm_quaternion
-HMM_AddQuaternion(hmm_quaternion Left, hmm_quaternion Right)
-{
-    hmm_quaternion Result;
-
-    Result.X = Left.X + Right.X;
-    Result.Y = Left.Y + Right.Y;
-    Result.Z = Left.Z + Right.Z;
-    Result.W = Left.W + Right.W;
-
-    return(Result);
-}
-
-HINLINE hmm_quaternion
-HMM_SubtractQuaternion(hmm_quaternion Left, hmm_quaternion Right)
-{
-    hmm_quaternion Result;
-
-    Result.X = Left.X - Right.X;
-    Result.Y = Left.Y - Right.Y;
-    Result.Z = Left.Z - Right.Z;
-    Result.W = Left.W - Right.W;
-
-    return(Result);
-}
-
-HINLINE hmm_quaternion
-HMM_MultiplyQuaternion(hmm_quaternion Left, hmm_quaternion Right)
-{
-    hmm_quaternion Result;
-
-    Result.X = (Left.X * Right.W) + (Left.Y * Right.Z) - (Left.Z * Right.Y) + (Left.W * Right.X);
-    Result.Y = (-Left.X * Right.Z) + (Left.Y * Right.W) + (Left.Z * Right.X) + (Left.W * Right.Y);
-    Result.Z = (Left.X * Right.Y) - (Left.Y * Right.X) + (Left.Z * Right.W) + (Left.W * Right.Z);
-    Result.W = (-Left.X * Right.X) - (Left.Y * Right.Y) - (Left.Z * Right.Z) + (Left.W * Right.W);
-
-    return(Result);
-}
-
-HINLINE hmm_quaternion
-HMM_MultiplyQuaternionF(hmm_quaternion Left, float Multiplicative)
-{
-    hmm_quaternion Result;
-
-    Result.X = Left.X * Multiplicative;
-    Result.Y = Left.Y * Multiplicative;
-    Result.Z = Left.Z * Multiplicative;
-    Result.W = Left.W * Multiplicative;
-
-    return(Result);
-}
-
-HINLINE hmm_quaternion
-HMM_DivideQuaternionF(hmm_quaternion Left, float Dividend)
-{
-    hmm_quaternion Result;
-
-    Result.X = Left.X / Dividend;
-    Result.Y = Left.Y / Dividend;
-    Result.Z = Left.Z / Dividend;
-    Result.W = Left.W / Dividend;
-
-    return(Result);
-}
-
-HINLINE hmm_quaternion
-HMM_InverseQuaternion(hmm_quaternion Left)
+hmm_quaternion HMM_InverseQuaternion(hmm_quaternion Left)
 {
     hmm_quaternion Conjugate;
     hmm_quaternion Result;
@@ -1896,47 +2328,10 @@ HMM_InverseQuaternion(hmm_quaternion Left)
     Result.Z = Conjugate.Z / NormSquared;
     Result.W = Conjugate.W / NormSquared;
 
-    return(Result);
+    return (Result);
 }
 
-HINLINE float
-HMM_DotQuaternion(hmm_quaternion Left, hmm_quaternion Right)
-{
-    float Result;
-
-    Result = (Left.X * Right.X) + (Left.Y * Right.Y) + (Left.Z * Right.Z) + (Left.W * Right.W);
-
-    return(Result);
-}
-
-HINLINE hmm_quaternion
-HMM_NormalizeQuaternion(hmm_quaternion Left)
-{
-    hmm_quaternion Result;
-
-    float Length = HMM_SquareRootF(HMM_DotQuaternion(Left, Left));
-    Result = HMM_DivideQuaternionF(Left, Length);
-
-    return(Result);
-}
-
-HINLINE hmm_quaternion
-HMM_NLerp(hmm_quaternion Left, float Time, hmm_quaternion Right)
-{
-    hmm_quaternion Result;
-
-    Result.X = HMM_Lerp(Left.X, Time, Right.X);
-    Result.Y = HMM_Lerp(Left.Y, Time, Right.Y);
-    Result.Z = HMM_Lerp(Left.Z, Time, Right.Z);
-    Result.W = HMM_Lerp(Left.W, Time, Right.W);
-
-    Result = HMM_NormalizeQuaternion(Result);
-
-    return(Result);
-}
-
-HINLINE hmm_quaternion
-HMM_Slerp(hmm_quaternion Left, float Time, hmm_quaternion Right)
+hmm_quaternion HMM_Slerp(hmm_quaternion Left, float Time, hmm_quaternion Right)
 {
     hmm_quaternion Result;
     hmm_quaternion QuaternionLeft;
@@ -1955,11 +2350,10 @@ HMM_Slerp(hmm_quaternion Left, float Time, hmm_quaternion Right)
     Result = HMM_AddQuaternion(QuaternionLeft, QuaternionRight);
     Result = HMM_MultiplyQuaternionF(Result, Is);
 
-    return(Result);
+    return (Result);
 }
 
-HINLINE hmm_mat4
-HMM_QuaternionToMat4(hmm_quaternion Left)
+hmm_mat4 HMM_QuaternionToMat4(hmm_quaternion Left)
 {
     hmm_mat4 Result;
     Result = HMM_Mat4d(1);
@@ -1992,11 +2386,10 @@ HMM_QuaternionToMat4(hmm_quaternion Left)
     Result.Elements[2][1] = 2.0f * (YZ - WX);
     Result.Elements[2][2] = 1.0f - 2.0f * (XX + YY);
 
-    return(Result);
+    return (Result);
 }
 
-HINLINE hmm_quaternion
-HMM_QuaternionFromAxisAngle(hmm_vec3 Axis, float AngleOfRotation)
+hmm_quaternion HMM_QuaternionFromAxisAngle(hmm_vec3 Axis, float AngleOfRotation)
 {
     hmm_quaternion Result;
     
@@ -2004,7 +2397,6 @@ HMM_QuaternionFromAxisAngle(hmm_vec3 Axis, float AngleOfRotation)
     
     float AxisNorm = 0;
     float SineOfRotation = 0;
-    
 
     AxisNorm = HMM_SquareRootF(HMM_DotVec3(Axis, Axis));
     SineOfRotation = HMM_SinF(AngleOfRotation / 2.0f);
@@ -2013,1011 +2405,7 @@ HMM_QuaternionFromAxisAngle(hmm_vec3 Axis, float AngleOfRotation)
     Result.W = HMM_CosF(AngleOfRotation / 2.0f);
     Result.XYZ = HMM_DivideVec3f(RotatedVector, AxisNorm);
 
-    return(Result);
-}
-
-#ifdef __cplusplus
-
-HINLINE float 
-HMM_Length(hmm_vec2 A)
-{
-    float Result;
-    
-    Result = HMM_LengthVec2(A);
-    
-    return(Result);
-}
-
-HINLINE float 
-HMM_Length(hmm_vec3 A)
-{
-    float Result;
-    
-    Result = HMM_LengthVec3(A);
-    
-    return(Result);
-}
-
-HINLINE float 
-HMM_Length(hmm_vec4 A)
-{
-    float Result;
-    
-    Result = HMM_LengthVec4(A);
-    
-    return(Result);
-}
-
-HINLINE float 
-HMM_LengthSquared(hmm_vec2 A)
-{
-    float Result;
-    
-    Result = HMM_LengthSquaredVec2(A);
-    
-    return(Result);
-}
-
-HINLINE float 
-HMM_LengthSquared(hmm_vec3 A)
-{
-    float Result;
-    
-    Result = HMM_LengthSquaredVec3(A);
-    
-    return(Result);
-}
-
-HINLINE float 
-HMM_LengthSquared(hmm_vec4 A)
-{
-    float Result;
-    
-    Result = HMM_LengthSquaredVec4(A);
-    
-    return(Result);
-}
-
-HINLINE hmm_vec2 
-HMM_Normalize(hmm_vec2 A)
-{
-    hmm_vec2 Result;
-    
-    Result = HMM_NormalizeVec2(A);    
-    
-    return(Result);
-}
-
-HINLINE hmm_vec3 
-HMM_Normalize(hmm_vec3 A)
-{
-    hmm_vec3 Result;
-    
-    Result = HMM_NormalizeVec3(A);
-    
-    return(Result);
-}
-
-HINLINE hmm_vec4 
-HMM_Normalize(hmm_vec4 A)
-{
-    hmm_vec4 Result;
-    
-    Result = HMM_NormalizeVec4(A);
-    
-    return(Result);
-}
-
-HINLINE hmm_quaternion
-HMM_Normalize(hmm_quaternion A)
-{
-    hmm_quaternion Result;
-
-    Result = HMM_NormalizeQuaternion(A);
-
-    return(Result);
-}
-
-HINLINE float 
-HMM_Dot(hmm_vec2 VecOne, hmm_vec2 VecTwo)
-{
-    float Result;
-    
-    Result = HMM_DotVec2(VecOne, VecTwo);
-    
-    return(Result);
-}
-
-HINLINE float 
-HMM_Dot(hmm_vec3 VecOne, hmm_vec3 VecTwo)
-{
-    float Result;
-    
-    Result = HMM_DotVec3(VecOne, VecTwo);
-    
-    return(Result);
-}
-
-HINLINE float 
-HMM_Dot(hmm_vec4 VecOne, hmm_vec4 VecTwo)
-{
-    float Result;
-    
-    Result = HMM_DotVec4(VecOne, VecTwo);
-    
-    return(Result);
-}
-
-HINLINE float
-HMM_Dot(hmm_quaternion QuatOne, hmm_quaternion QuatTwo)
-{
-    float Result;
-
-    Result = HMM_DotQuaternion(QuatOne, QuatTwo);
-
-    return(Result);
-}
-
-HINLINE hmm_vec2
-HMM_Add(hmm_vec2 Left, hmm_vec2 Right)
-{
-    hmm_vec2 Result;
-
-    Result = HMM_AddVec2(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec3
-HMM_Add(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result;
-
-    Result = HMM_AddVec3(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec4
-HMM_Add(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result;
-
-    Result = HMM_AddVec4(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_mat4
-HMM_Add(hmm_mat4 Left, hmm_mat4 Right)
-{
-    hmm_mat4 Result;
-
-    Result = HMM_AddMat4(Left, Right);
-    
-    return (Result);    
-}
-
-HINLINE hmm_quaternion
-HMM_Add(hmm_quaternion Left, hmm_quaternion Right)
-{
-    hmm_quaternion Result;
-
-    Result = HMM_AddQuaternion(Left, Right);
-    
-    return(Result);
-}
-
-HINLINE hmm_vec2
-HMM_Subtract(hmm_vec2 Left, hmm_vec2 Right)
-{
-    hmm_vec2 Result;
-
-    Result = HMM_SubtractVec2(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec3
-HMM_Subtract(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result;
-
-    Result = HMM_SubtractVec3(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec4
-HMM_Subtract(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result;
-
-    Result = HMM_SubtractVec4(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_mat4
-HMM_Subtract(hmm_mat4 Left, hmm_mat4 Right)
-{
-    hmm_mat4 Result;
-
-    Result = HMM_SubtractMat4(Left, Right);
-        
-    return (Result);
-}
-
-HINLINE hmm_quaternion
-HMM_Subtract(hmm_quaternion Left, hmm_quaternion Right)
-{
-    hmm_quaternion Result;
-
-    Result = HMM_SubtractQuaternion(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec2
-HMM_Multiply(hmm_vec2 Left, hmm_vec2 Right)
-{
-    hmm_vec2 Result;
-
-    Result = HMM_MultiplyVec2(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec2
-HMM_Multiply(hmm_vec2 Left, float Right)
-{
-    hmm_vec2 Result;
-
-    Result = HMM_MultiplyVec2f(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec3
-HMM_Multiply(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result;
-
-    Result = HMM_MultiplyVec3(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec3
-HMM_Multiply(hmm_vec3 Left, float Right)
-{
-    hmm_vec3 Result;
-
-    Result = HMM_MultiplyVec3f(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec4
-HMM_Multiply(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result;
-
-    Result = HMM_MultiplyVec4(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec4
-HMM_Multiply(hmm_vec4 Left, float Right)
-{
-    hmm_vec4 Result;
-
-    Result = HMM_MultiplyVec4f(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_mat4
-HMM_Multiply(hmm_mat4 Left, hmm_mat4 Right)
-{
-    hmm_mat4 Result;
-
-    Result = HMM_MultiplyMat4(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_mat4
-HMM_Multiply(hmm_mat4 Left, float Right)
-{
-    hmm_mat4 Result;
-
-    Result = HMM_MultiplyMat4f(Left, Right);
-    
-    return (Result);    
-}
-
-HINLINE hmm_vec4
-HMM_Multiply(hmm_mat4 Matrix, hmm_vec4 Vector)
-{
-    hmm_vec4 Result;
-
-    Result = HMM_MultiplyMat4ByVec4(Matrix, Vector);
-    
-    return (Result);
-}
-
-HINLINE hmm_quaternion
-HMM_Multiply(hmm_quaternion Left, hmm_quaternion Right)
-{
-    hmm_quaternion Result;
-
-    Result = HMM_MultiplyQuaternion(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_quaternion
-HMM_Multiply(hmm_quaternion Left, float Right)
-{
-    hmm_quaternion Result;
-
-    Result = HMM_MultiplyQuaternionF(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_quaternion
-HMM_Multiply(float Left, hmm_quaternion Right)
-{
-    hmm_quaternion Result;
-
-    Result = HMM_MultiplyQuaternionF(Right, Left);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec2
-HMM_Divide(hmm_vec2 Left, hmm_vec2 Right)
-{
-    hmm_vec2 Result;
-
-    Result = HMM_DivideVec2(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec2
-HMM_Divide(hmm_vec2 Left, float Right)
-{
-    hmm_vec2 Result;
-
-    Result = HMM_DivideVec2f(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec3
-HMM_Divide(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result;
-
-    Result = HMM_DivideVec3(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec3
-HMM_Divide(hmm_vec3 Left, float Right)
-{
-    hmm_vec3 Result;
-
-    Result = HMM_DivideVec3f(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec4
-HMM_Divide(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result;
-
-    Result = HMM_DivideVec4(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec4
-HMM_Divide(hmm_vec4 Left, float Right)
-{
-    hmm_vec4 Result;
-
-    Result = HMM_DivideVec4f(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_mat4
-HMM_Divide(hmm_mat4 Left, float Right)
-{
-    hmm_mat4 Result;
-
-    Result = HMM_DivideMat4f(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_quaternion
-HMM_Divide(hmm_quaternion Left, float Right)
-{
-    hmm_quaternion Result;
-
-    Result = HMM_DivideQuaternionF(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_bool
-HMM_Equals(hmm_vec2 Left, hmm_vec2 Right)
-{
-    hmm_bool Result;
-
-    Result = HMM_EqualsVec2(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_bool
-HMM_Equals(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_bool Result;
-
-    Result = HMM_EqualsVec3(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_bool
-HMM_Equals(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_bool Result;
-
-    Result = HMM_EqualsVec4(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec2
-operator+(hmm_vec2 Left, hmm_vec2 Right)
-{
-    hmm_vec2 Result;
-
-    Result = HMM_Add(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec3
-operator+(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result;
-
-    Result = HMM_Add(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec4
-operator+(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result;
-
-    Result = HMM_Add(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_mat4
-operator+(hmm_mat4 Left, hmm_mat4 Right)
-{
-    hmm_mat4 Result;
-
-    Result = HMM_Add(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_quaternion
-operator+(hmm_quaternion Left, hmm_quaternion Right)
-{
-    hmm_quaternion Result;
-
-    Result = HMM_Add(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec2
-operator-(hmm_vec2 Left, hmm_vec2 Right)
-{
-    hmm_vec2 Result;
-
-    Result = HMM_Subtract(Left, Right);
-    
     return (Result);
-}
-
-HINLINE hmm_vec3
-operator-(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result;
-
-    Result = HMM_Subtract(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec4
-operator-(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result;
-
-    Result = HMM_Subtract(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_mat4
-operator-(hmm_mat4 Left, hmm_mat4 Right)
-{
-    hmm_mat4 Result;
-
-    Result = HMM_Subtract(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_quaternion
-operator-(hmm_quaternion Left, hmm_quaternion Right)
-{
-    hmm_quaternion Result;
-
-    Result = HMM_Subtract(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec2
-operator*(hmm_vec2 Left, hmm_vec2 Right)
-{
-    hmm_vec2 Result;
-
-    Result = HMM_Multiply(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec3
-operator*(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result;
-
-    Result = HMM_Multiply(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec4
-operator*(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result;
-        
-    Result = HMM_Multiply(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_vec2
-operator*(hmm_vec2 Left, float Right)
-{
-    hmm_vec2 Result;
-
-    Result = HMM_Multiply(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec3
-operator*(hmm_vec3 Left, float Right)
-{
-    hmm_vec3 Result;
-
-    Result = HMM_Multiply(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec4
-operator*(hmm_vec4 Left, float Right)
-{
-    hmm_vec4 Result;
-
-    Result = HMM_Multiply(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_mat4
-operator*(hmm_mat4 Left, float Right)
-{
-    hmm_mat4 Result;
-
-    Result = HMM_Multiply(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec2
-operator*(float Left, hmm_vec2 Right)
-{
-    hmm_vec2 Result;
-
-    Result = HMM_Multiply(Right, Left);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec3
-operator*(float Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result;
-
-    Result = HMM_Multiply(Right, Left);
-    return (Result);
-}
-
-HINLINE hmm_vec4
-operator*(float Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result;
-
-    Result = HMM_Multiply(Right, Left);
-    return (Result);
-}
-
-HINLINE hmm_mat4
-operator*(float Left, hmm_mat4 Right)
-{
-    hmm_mat4 Result;
-
-    Result = HMM_Multiply(Right, Left);
-    
-    return (Result);
-}
-
-HINLINE hmm_mat4
-operator*(hmm_mat4 Left, hmm_mat4 Right)
-{
-    hmm_mat4 Result;
-
-    Result = HMM_Multiply(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec4
-operator*(hmm_mat4 Matrix, hmm_vec4 Vector)
-{
-    hmm_vec4 Result;
-
-    Result = HMM_Multiply(Matrix, Vector);
-    
-    return (Result);
-}
-
-HINLINE hmm_quaternion
-operator*(hmm_quaternion Left, hmm_quaternion Right)
-{
-    hmm_quaternion Result;
-
-    Result = HMM_Multiply(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_quaternion
-operator*(hmm_quaternion Left, float Right)
-{
-    hmm_quaternion Result;
-
-    Result = HMM_Multiply(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_quaternion
-operator*(float Left, hmm_quaternion Right)
-{
-    hmm_quaternion Result;
-
-    Result = HMM_Multiply(Right, Left);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec2
-operator/(hmm_vec2 Left, hmm_vec2 Right)
-{
-    hmm_vec2 Result;
-
-    Result = HMM_Divide(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec3
-operator/(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result;
-    
-    Result = HMM_Divide(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_vec4
-operator/(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result;
-
-    Result = HMM_Divide(Left, Right);
-    return (Result);
-}
-
-HINLINE hmm_vec2
-operator/(hmm_vec2 Left, float Right)
-{
-    hmm_vec2 Result;
-
-    Result = HMM_Divide(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec3
-operator/(hmm_vec3 Left, float Right)
-{
-    hmm_vec3 Result;
-
-    Result = HMM_Divide(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec4
-operator/(hmm_vec4 Left, float Right)
-{
-    hmm_vec4 Result;
-
-    Result = HMM_Divide(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_mat4
-operator/(hmm_mat4 Left, float Right)
-{
-    hmm_mat4 Result;
-
-    Result = HMM_Divide(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_quaternion
-operator/(hmm_quaternion Left, float Right)
-{
-    hmm_quaternion Result;
-
-    Result = HMM_Divide(Left, Right);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec2 &
-operator+=(hmm_vec2 &Left, hmm_vec2 Right)
-{    
-    return (Left = Left + Right);
-}
-
-HINLINE hmm_vec3 &
-operator+=(hmm_vec3 &Left, hmm_vec3 Right)
-{    
-    return (Left = Left + Right);
-}
-
-HINLINE hmm_vec4 &
-operator+=(hmm_vec4 &Left, hmm_vec4 Right)
-{    
-    return (Left = Left + Right);
-}
-
-HINLINE hmm_mat4 &
-operator+=(hmm_mat4 &Left, hmm_mat4 Right)
-{
-    return (Left = Left + Right);
-}
-
-HINLINE hmm_quaternion &
-operator+=(hmm_quaternion &Left, hmm_quaternion Right)
-{
-    return (Left = Left + Right);
-}
-
-HINLINE hmm_vec2 &
-operator-=(hmm_vec2 &Left, hmm_vec2 Right)
-{    
-    return (Left = Left - Right);
-}
-
-HINLINE hmm_vec3 &
-operator-=(hmm_vec3 &Left, hmm_vec3 Right)
-{    
-    return (Left = Left - Right);
-}
-
-HINLINE hmm_vec4 &
-operator-=(hmm_vec4 &Left, hmm_vec4 Right)
-{    
-    return (Left = Left - Right);
-}
-
-HINLINE hmm_mat4 &
-operator-=(hmm_mat4 &Left, hmm_mat4 Right)
-{
-    return (Left = Left - Right);
-}
-
-HINLINE hmm_quaternion &
-operator-=(hmm_quaternion &Left, hmm_quaternion Right)
-{
-    return (Left = Left - Right);
-}
-
-HINLINE hmm_vec2 &
-operator/=(hmm_vec2 &Left, hmm_vec2 Right)
-{    
-    return (Left = Left / Right);
-}
-
-HINLINE hmm_vec3 &
-operator/=(hmm_vec3 &Left, hmm_vec3 Right)
-{    
-    return (Left = Left / Right);
-}
-
-HINLINE hmm_vec4 &
-operator/=(hmm_vec4 &Left, hmm_vec4 Right)
-{    
-    return (Left = Left / Right);
-}
-
-HINLINE hmm_vec2 &
-operator/=(hmm_vec2 &Left, float Right)
-{
-    return (Left = Left / Right);
-}
-
-HINLINE hmm_vec3 &
-operator/=(hmm_vec3 &Left, float Right)
-{
-    return (Left = Left / Right);
-}
-
-HINLINE hmm_vec4 &
-operator/=(hmm_vec4 &Left, float Right)
-{
-    return (Left = Left / Right);
-}
-
-HINLINE hmm_mat4 &
-operator/=(hmm_mat4 &Left, float Right)
-{
-    return (Left = Left / Right);
-}
-
-HINLINE hmm_quaternion &
-operator/=(hmm_quaternion &Left, float Right)
-{
-    return (Left = Left / Right);
-}
-
-HINLINE hmm_vec2 &
-operator*=(hmm_vec2 &Left, hmm_vec2 Right)
-{    
-    return (Left = Left * Right);
-}
-
-HINLINE hmm_vec3 &
-operator*=(hmm_vec3 &Left, hmm_vec3 Right)
-{    
-    return (Left = Left * Right);
-}
-
-HINLINE hmm_vec4 &
-operator*=(hmm_vec4 &Left, hmm_vec4 Right)
-{    
-    return (Left = Left * Right);
-}
-
-HINLINE hmm_vec2 &
-operator*=(hmm_vec2 &Left, float Right)
-{
-    return (Left = Left * Right);
-}
-
-HINLINE hmm_vec3 &
-operator*=(hmm_vec3 &Left, float Right)
-{
-    return (Left = Left * Right);
-}
-
-HINLINE hmm_vec4 &
-operator*=(hmm_vec4 &Left, float Right)
-{
-    return (Left = Left * Right);
-}
-
-HINLINE hmm_mat4 &
-operator*=(hmm_mat4 &Left, float Right)
-{
-    return (Left = Left * Right);
-}
-
-HINLINE hmm_quaternion &
-operator*=(hmm_quaternion &Left, float Right)
-{
-    return (Left = Left * Right);
-}
-
-HINLINE hmm_bool
-operator==(hmm_vec2 Left, hmm_vec2 Right)
-{
-    return HMM_EqualsVec2(Left, Right);    
-}
-
-HINLINE hmm_bool
-operator==(hmm_vec3 Left, hmm_vec3 Right)
-{
-    return HMM_EqualsVec3(Left, Right);    
-}
-
-HINLINE hmm_bool
-operator==(hmm_vec4 Left, hmm_vec4 Right)
-{
-    return HMM_EqualsVec4(Left, Right);    
-}
-
-
-HINLINE hmm_bool 
-operator!=(hmm_vec2 Left, hmm_vec2 Right)
-{
-    return !HMM_EqualsVec2(Left, Right);    
-}
-
-HINLINE hmm_bool 
-operator!=(hmm_vec3 Left, hmm_vec3 Right)
-{
-    return !HMM_EqualsVec3(Left, Right);    
-}
-
-HINLINE hmm_bool 
-operator!=(hmm_vec4 Left, hmm_vec4 Right)
-{
-    return !HMM_EqualsVec4(Left, Right);    
 }
-
-#endif /* __cplusplus */
 
 #endif /* HANDMADE_MATH_IMPLEMENTATION */

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ _This library is free and will stay free, but if you would like to support devel
 
 Version         | Changes        | 
 ----------------|----------------|
+**1.5.0** | Changed internal structure for better performance and inlining. As a result, `HANDMADE_MATH_NO_INLINE` has been removed and no longer has any effect.
 **1.4.0** | Fixed bug when using C mode. SSE'd all vec4 operations. Removed zeroing for better performance.
 **1.3.0** | Removed need to `#define HANDMADE_MATH_CPP_MODE`. C++ definitions are now included automatically in C++ environments.
 **1.2.0** | Added equality functions for `HMM_Vec2`, `HMM_Vec3`, and `HMM_Vec4`, and SSE'd `HMM_MultiplyMat4` and `HMM_Transpose`.


### PR DESCRIPTION
As per @DanielGibson's suggestions in #57, most functions in Handmade Math are now `static inline` and do not have separate prototype and implementation. Longer functions like `HMM_Rotate` are not marked as inline.

Resolves #57.