### PR TITLE
Use SSE for HMM_MultiplyMat4ByVec4

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -2259,7 +2259,10 @@ hmm_mat4 HMM_MultiplyMat4f(hmm_mat4 Matrix, float Scalar)
 hmm_vec4 HMM_MultiplyMat4ByVec4(hmm_mat4 Matrix, hmm_vec4 Vector)
 {
     hmm_vec4 Result;
-    
+   
+#ifdef HANDMADE_MATH__USE_SSE
+	Result.InternalElementsSSE = HMM_LinearCombineSSE(Vector.InternalElementsSSE, Matrix);
+#else
     int Columns, Rows;
     for(Rows = 0; Rows < 4; ++Rows)
     {
@@ -2271,7 +2274,8 @@ hmm_vec4 HMM_MultiplyMat4ByVec4(hmm_mat4 Matrix, hmm_vec4 Vector)
         
         Result.Elements[Rows] = Sum;
     }
-    
+#endif
+
     return (Result);
 }
 


### PR DESCRIPTION
Uses SSE for HMM_MultiplyMat4ByVec4 by implementing it with HMM_LinearCombineSSE if SSE is enabled.

Quickbench for comparison: http://quick-bench.com/p44dVIPijYFj8uIm1NuerNiaSB8
With GCC it barely makes a difference since it auto-vectorizes it, but Clang doesn't do that.