### PR TITLE
Removed copy in operator[]

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -324,7 +324,7 @@ typedef union hmm_vec2
     float Elements[2];
 
 #ifdef __cplusplus
-    inline float &operator[](int Index)
+    inline float &operator[](const int &Index)
     {
         return Elements[Index];
     }
@@ -375,7 +375,7 @@ typedef union hmm_vec3
     float Elements[3];
 
 #ifdef __cplusplus
-    inline float &operator[](int Index)
+    inline float &operator[](const int &Index)
     {
         return Elements[Index];
     }
@@ -439,7 +439,7 @@ typedef union hmm_vec4
 #endif
 
 #ifdef __cplusplus
-    inline float &operator[](int Index)
+    inline float &operator[](const int &Index)
     {
         return Elements[Index];
     }
@@ -459,7 +459,7 @@ typedef union hmm_mat4
 #endif
 
 #ifdef __cplusplus
-    inline hmm_vec4 operator[](const int Index)
+    inline hmm_vec4 operator[](const int &Index)
     {
         float* col = Elements[Index];
 

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -1,5 +1,5 @@
 /*
-  HandmadeMath.h v1.7.0
+  HandmadeMath.h v1.7.1
   
   This is a single header file with a bunch of useful functions for game and
   graphics math operations.
@@ -176,7 +176,10 @@
           (*) Renamed the 'Rows' member of hmm_mat4 to 'Columns'. Since our
               matrices are column-major, this should have been named 'Columns'
               from the start. 'Rows' is still present, but has been deprecated.
-
+     1.7.1
+          (*) Changed operator[] to take in a const ref int instead of a int. 
+              Simple dumb mistake. NOTE: The compiler still wont inline operator[]
+              for some reason 
 
   LICENSE
   

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ To get started, go download [the latest release](https://github.com/HandmadeMath
 
 Version         | Changes        |
 ----------------|----------------|
+**1.7.1** | Changed operator[] to take in a const ref int instead of a int. Simple mistake
 **1.7.0** | Renamed the 'Rows' member of hmm_mat4 to 'Columns'. Since our matrices are column-major, this should have been named 'Columns' from the start. 'Rows' is still present, but has been deprecated.
 **1.6.0** | Added array subscript operators for vector and matrix types in C++. This is provided as a convenience, but be aware that it may incur an extra function call in unoptimized builds.
 **1.5.1** | Fixed a bug with uninitialized elements in HMM_LookAt.


### PR DESCRIPTION
Made the operator[] take in a const ref int instead of just a const int to prevent a copy. Using this operator shouldn't be as expensive now. 

