### PR TITLE
Added SSE support for Quaternion operations

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -1299,15 +1299,21 @@ HMM_INLINE hmm_quaternion HMM_MultiplyQuaternion(hmm_quaternion Left, hmm_quater
     hmm_quaternion Result;
 
 #ifdef HANDMADE_MATH__USE_SSE
-    __m128 SSEResultOne = _mm_mul_ps(_mm_shuffle_ps(Left.InternalElementsSSE, Left.InternalElementsSSE, _MM_SHUFFLE(1, 1, 2, 3)), _mm_shuffle_ps(Right.InternalElementsSSE, Right.InternalElementsSSE, _MM_SHUFFLE(1, 0, 0, 0)));
-    __m128 SSEResultTwo = _mm_mul_ps(_mm_shuffle_ps(Left.InternalElementsSSE, Left.InternalElementsSSE, _MM_SHUFFLE(2, 2, 3, 1)), _mm_shuffle_ps(Right.InternalElementsSSE, Right.InternalElementsSSE, _MM_SHUFFLE(2, 3, 1, 2)));
-    __m128 SSEResultThree = _mm_add_ps(SSEResultOne, SSEResultTwo);
+        __m128 SSEResultOne = _mm_xor_ps(_mm_shuffle_ps(Left.InternalElementsSSE, Left.InternalElementsSSE, _MM_SHUFFLE(0, 0, 0, 0)), _mm_setr_ps(0.f, -0.f, 0.f, -0.f));
+        __m128 SSEResultTwo = _mm_shuffle_ps(Right.InternalElementsSSE, Right.InternalElementsSSE, _MM_SHUFFLE(0, 1, 2, 3));
+        __m128 SSEResultThree = _mm_mul_ps(SSEResultTwo, SSEResultOne);
 
-    __m128 a3312 = _mm_shuffle_ps(Left.InternalElementsSSE, Left.InternalElementsSSE, _MM_SHUFFLE(3, 3, 1, 2));
-    __m128 b3231 = _mm_shuffle_ps(Right.InternalElementsSSE, Right.InternalElementsSSE, _MM_SHUFFLE(3, 2, 3, 1));
-    __m128 a0000 = _mm_shuffle_ps(Left.InternalElementsSSE, Left.InternalElementsSSE, _MM_SHUFFLE(0, 0, 0, 0));
+        SSEResultOne = _mm_xor_ps(_mm_shuffle_ps(Left.InternalElementsSSE, Left.InternalElementsSSE, _MM_SHUFFLE(1, 1, 1, 1)) , _mm_setr_ps(0.f, 0.f, -0.f, -0.f));
+        SSEResultTwo = _mm_shuffle_ps(Right.InternalElementsSSE, Right.InternalElementsSSE, _MM_SHUFFLE(1, 0, 3, 2));
+        SSEResultThree = _mm_add_ps(SSEResultThree, _mm_mul_ps(SSEResultTwo, SSEResultOne));
 
-    Result.InternalElementsSSE = _mm_add_ps(_mm_sub_ps(_mm_mul_ps(a0000, Right.InternalElementsSSE), _mm_mul_ps(a3312, b3231)), _mm_xor_ps(SSEResultThree, _mm_castsi128_ps(_mm_set_epi32(0, 0, 0, 0x80000000))));
+        SSEResultOne = _mm_xor_ps(_mm_shuffle_ps(Left.InternalElementsSSE, Left.InternalElementsSSE, _MM_SHUFFLE(2, 2, 2, 2)), _mm_setr_ps(-0.f, 0.f, 0.f, -0.f));
+        SSEResultTwo = _mm_shuffle_ps(Right.InternalElementsSSE, Right.InternalElementsSSE, _MM_SHUFFLE(2, 3, 0, 1));
+        SSEResultThree = _mm_add_ps(SSEResultThree, _mm_mul_ps(SSEResultTwo, SSEResultOne));
+
+        SSEResultOne = _mm_shuffle_ps(Left.InternalElementsSSE, Left.InternalElementsSSE, _MM_SHUFFLE(3, 3, 3, 3));
+        SSEResultTwo = _mm_shuffle_ps(Right.InternalElementsSSE, Right.InternalElementsSSE, _MM_SHUFFLE(3, 2, 1, 0));
+        Result.InternalElementsSSE = _mm_add_ps(SSEResultThree, _mm_mul_ps(SSEResultTwo, SSEResultOne));
 #else
     Result.X = (Left.X * Right.W) + (Left.Y * Right.Z) - (Left.Z * Right.Y) + (Left.W * Right.X);
     Result.Y = (-Left.X * Right.Z) + (Left.Y * Right.W) + (Left.Z * Right.X) + (Left.W * Right.Y);


### PR DESCRIPTION
Added SSE support for almost all operations involving quaternions (Inverse, NLerp, Normalize, Dot, DivF, MulF, Mul, Sub, Add). SLerp also mostly supports SSE now since it largely calls the other quaternion operations. 

Benchmarks:
```

Optimization: O2
| Function    |     SSE         |      NO SSE      |
====================================================
| Inverse     |     163 (0.89s) |      165 (1.89s) |
| NLerp       |     330 (1.70s) |      330 (1.75s) |
| Normalize   |     169 (1.03s) |      169 (1.06s) |
| Dot         |     22  (1.15s) |      23  (1.14s) |
| DivF        |     23  (0.72s) |      23  (0.82s) |
| MulF        |     22  (0.75s) |      22  (0.79s) |
| Mul         |     24  (1.14s) |      23  (1.24s) |
| Sub         |     23  (1.17s) |      37  (1.20s) |
| Add         |     23  (1.20s) |      24  (1.19s) |

Where values are:  avg cycles spent in operation (avg total execution time in seconds)


Optimization: O0
| Function    |     SSE         |      NO SSE      |
====================================================
| Inverse     |     394 (1.62s) |      430 (3.05s) |
| NLerp       |     694 (2.71s) |      1035(4.81s) |
| Normalize   |     374 (1.58s) |      412 (2.95s) |
| Dot         |     81  (1.83s) |      23  (2.50s) |
| DivF        |     61  (1.12s) |      25  (2.37s) |
| MulF        |     58  (1.09s) |      23  (2.31s) |
| Mul         |     94  (1.97s) |      42  (2.88s) |
| Sub         |     75  (1.83s) |      23  (2.82s) |
| Add         |     75  (1.81s) |      23  (2.81s) |

Where values are: avg cycles spent in operation (avg total execution time in seconds)

Each benchmark was 10 executions of a test containing 10,000,000 operations. 
```

Tests:
```
ScalarMath:
    Trigonometry: [PASS] (15/15 passed)
    ToRadians: [PASS] (3/3 passed)
    SquareRoot: [PASS] (1/1 passed)
    RSquareRootF: [PASS] (1/1 passed)
    Power: [PASS] (3/3 passed)
    PowerF: [PASS] (3/3 passed)
    Lerp: [PASS] (3/3 passed)
    Clamp: [PASS] (3/3 passed)
8/8 tests passed, 0 failures

Initialization:
    Vectors: [PASS] (148/148 passed)
    MatrixEmpty: [PASS] (32/32 passed)
    MatrixDiagonal: [PASS] (16/16 passed)
    Quaternion: [PASS] (12/12 passed)
4/4 tests passed, 0 failures

VectorOps:
    LengthSquared: [PASS] (6/6 passed)
    Length: [PASS] (6/6 passed)
    Normalize: [PASS] (24/24 passed)
    NormalizeZero: [PASS] (18/18 passed)
    FastNormalize: [PASS] (24/24 passed)
    FastNormalizeZero: [PASS] (18/18 passed)
    Cross: [PASS] (3/3 passed)
    DotVec2: [PASS] (2/2 passed)
    DotVec3: [PASS] (2/2 passed)
    DotVec4: [PASS] (2/2 passed)
10/10 tests passed, 0 failures

MatrixOps:
    Transpose: [PASS] (16/16 passed)
1/1 tests passed, 0 failures

QuaternionOps:
    Inverse: [PASS] (4/4 passed)
    Dot: [PASS] (2/2 passed)
    Normalize: [PASS] (8/8 passed)
    NLerp: [PASS] (4/4 passed)
    Slerp: [PASS] (4/4 passed)
    ToMat4: [PASS] (16/16 passed)
    FromAxisAngle: [PASS] (4/4 passed)
7/7 tests passed, 0 failures

Addition:
    Vec2: [PASS] (8/8 passed)
    Vec3: [PASS] (12/12 passed)
    Vec4: [PASS] (16/16 passed)
    Mat4: [PASS] (64/64 passed)
    Quaternion: [PASS] (16/16 passed)
5/5 tests passed, 0 failures

Subtraction:
    Vec2: [PASS] (8/8 passed)
    Vec3: [PASS] (12/12 passed)
    Vec4: [PASS] (16/16 passed)
    Mat4: [PASS] (64/64 passed)
    Quaternion: [PASS] (16/16 passed)
5/5 tests passed, 0 failures

Multiplication:
    Vec2Vec2: [PASS] (8/8 passed)
    Vec2Scalar: [PASS] (10/10 passed)
    Vec3Vec3: [PASS] (12/12 passed)
    Vec3Scalar: [PASS] (15/15 passed)
    Vec4Vec4: [PASS] (16/16 passed)
    Vec4Scalar: [PASS] (19/19 passed)
    Mat4Mat4: [PASS] (48/48 passed)
    Mat4Scalar: [PASS] (80/80 passed)
    Mat4Vec4: [PASS] (12/12 passed)
    QuaternionQuaternion: [PASS] (12/12 passed)
    QuaternionScalar: [PASS] (20/20 passed)
11/11 tests passed, 0 failures

Division:
    Vec2Vec2: [PASS] (8/8 passed)
    Vec2Scalar: [PASS] (8/8 passed)
    Vec3Vec3: [PASS] (12/12 passed)
    Vec3Scalar: [PASS] (12/12 passed)
    Vec4Vec4: [PASS] (16/16 passed)
    Vec4Scalar: [PASS] (16/16 passed)
    Mat4Scalar: [PASS] (64/64 passed)
    QuaternionScalar: [PASS] (16/16 passed)
8/8 tests passed, 0 failures

Equality:
    Vec2: [PASS] (6/6 passed)
    Vec3: [PASS] (6/6 passed)
    Vec4: [PASS] (6/6 passed)
3/3 tests passed, 0 failures

Projection:
    Orthographic: [PASS] (4/4 passed)
    Perspective: [PASS] (8/8 passed)
2/2 tests passed, 0 failures

Transformations:
    Translate: [PASS] (4/4 passed)
    Rotate: [PASS] (12/12 passed)
    Scale: [PASS] (4/4 passed)
    LookAt: [PASS] (16/16 passed)
4/4 tests passed, 0 failures

SSE:
    LinearCombine: [PASS] (16/16 passed)
1/1 tests passed, 0 failures

69/69 tests passed overall, 0 failures
```


