### PR TITLE
Fixed issue related to unsigned/signed-ness of HMM_Power

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -129,6 +129,11 @@
 #pragma GCC diagnostic ignored "-Wgnu-anonymous-struct"
 #endif
 
+#if defined(__GNUC__) && (__GNUC__ == 4 && __GNUC_MINOR__ < 8)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-braces"
+#endif
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -2164,6 +2169,10 @@ HMM_INLINE hmm_bool operator!=(hmm_vec4 Left, hmm_vec4 Right)
 #endif /* __cplusplus */
 
 #ifdef __clang__
+#pragma GCC diagnostic pop
+#endif
+
+#if defined(__GNUC__) && (__GNUC__ == 4 && __GNUC_MINOR__ < 8)
 #pragma GCC diagnostic pop
 #endif
 

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -2175,7 +2175,7 @@ float HMM_Power(float Base, int Exponent)
 {
     float Result = 1.0f;
     float Mul = Exponent < 0 ? 1.f / Base : Base;
-    unsigned int X = Exponent < 0 ? -Exponent : Exponent;
+    int X = Exponent < 0 ? -Exponent : Exponent;
     while (X)
     {
         if (X & 1)


### PR DESCRIPTION
Fixes warning on GCC when compiling with -Weverything

`./HandmadeMath.h:2178:37: warning: operand of ? changes signedness: 'int' to 'unsigned int' [-Wsign-conversion]
    unsigned int X = Exponent < 0 ? -Exponent : Exponent;
                 ~                  ^~~~~~~~~
./HandmadeMath.h:2178:49: warning: operand of ? changes signedness: 'int' to 'unsigned int' [-Wsign-conversion]
    unsigned int X = Exponent < 0 ? -Exponent : Exponent;
                 ~                              ^~~~~~~~
`

Had an issue with unsigned/signed. We were using a regular "int" as the parameter. Making it unsigned would make no sense due to the comparison

This CL simply removes the "unsigned" from the variable X to prevent the warning from generating again.

