### PR TITLE
Removed use of stdint.h

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -1,5 +1,5 @@
 /*
-  HandmadeMath.h v1.9.0
+  HandmadeMath.h v1.10.1
 
   This is a single header file with a bunch of useful functions for game and
   graphics math operations.
@@ -118,8 +118,6 @@
 # endif /* not _MSC_VER */
 
 #endif /* #ifndef HANDMADE_MATH_NO_SSE */
-
-#include <stdint.h> // This is for types
 
 #ifdef HANDMADE_MATH__USE_SSE
 #include <xmmintrin.h>
@@ -399,7 +397,7 @@ typedef union hmm_quaternion
 #endif
 } hmm_quaternion;
 
-typedef int32_t hmm_bool;
+typedef signed int hmm_bool;
 
 typedef hmm_vec2 hmm_v2;
 typedef hmm_vec3 hmm_v3;

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ To get started, go download [the latest release](https://github.com/HandmadeMath
 
 Version         | Changes        |
 ----------------|----------------|
+**1.10.1** | Removed stdint.h, this doesn't exist on some really old compilers and we didn't really use it anyways. |
 **1.10.0** | Made HMM_Perspective use vertical FOV instead of horizontal FOV for consistency with other graphics APIs. |
 **1.9.0** | Added SSE versions of quaternion operations. |
 **1.8.0** | Added fast vector normalization routines that use fast inverse square roots.


### PR DESCRIPTION
stdint.h doesn't exist on some really old compiler, and we weren't really using it anyways so i removed the use of it. Handmade math should compile cleanly without any headers now (unless you want SSE optimizations, because you need the include for those types).