### PR TITLE
Suppress float equality warnings

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -140,6 +140,14 @@
 #pragma GCC diagnostic ignored "-Wmissing-braces"
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+#define HMM_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#elif defined(_MSC_VER)
+#define HMM_DEPRECATED(msg) __declspec(deprecated(msg))
+#else
+#define HMM_DEPRECATED(msg)
+#endif
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -353,8 +361,7 @@ typedef union hmm_mat4
 #ifdef HANDMADE_MATH__USE_SSE
     __m128 Columns[4];
 
-    // DEPRECATED. Our matrices are column-major, so this was named
-    // incorrectly. Use Columns instead.
+    HMM_DEPRECATED("Our matrices are column-major, so this was named incorrectly. Use Columns instead.")
     __m128 Rows[4];
 #endif
 

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -130,14 +130,15 @@
 #pragma warning(disable:4201)
 #endif
 
-#ifdef __clang__
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#if defined(__GNUC__) && (__GNUC__ == 4 && __GNUC_MINOR__ < 8)
+#pragma GCC diagnostic ignored "-Wmissing-braces"
+#endif
+#ifdef __clang__
 #pragma GCC diagnostic ignored "-Wgnu-anonymous-struct"
 #endif
-
-#if defined(__GNUC__) && (__GNUC__ == 4 && __GNUC_MINOR__ < 8)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmissing-braces"
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)
@@ -2776,11 +2777,7 @@ HMM_INLINE hmm_bool operator!=(hmm_vec4 Left, hmm_vec4 Right)
 
 #endif /* __cplusplus */
 
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
-
-#if defined(__GNUC__) && (__GNUC__ == 4 && __GNUC_MINOR__ < 8)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,6 @@
 BUILD_DIR=./build
 
-CXXFLAGS+=-g -Wall -Wextra -pthread -Wno-missing-braces -Wno-missing-field-initializers
+CXXFLAGS+=-g -Wall -Wextra -pthread -Wno-missing-braces -Wno-missing-field-initializers -Wfloat-equal
 
 all: c c_no_sse cpp cpp_no_sse build_c_without_coverage build_cpp_without_coverage
 

--- a/test/categories/ScalarMath.h
+++ b/test/categories/ScalarMath.h
@@ -74,9 +74,9 @@ TEST(ScalarMath, Power)
 
 TEST(ScalarMath, PowerF)
 {
-    EXPECT_FLOAT_EQ(HMM_PowerF(2.0f, 0), 1.0f);
-    EXPECT_NEAR(HMM_PowerF(2.0f, 4.1), 17.148376f, 0.0001f);
-    EXPECT_NEAR(HMM_PowerF(2.0f, -2.5), 0.176777f, 0.0001f);
+    EXPECT_FLOAT_EQ(HMM_PowerF(2.0f, 0.0f), 1.0f);
+    EXPECT_NEAR(HMM_PowerF(2.0f, 4.1f), 17.148376f, 0.0001f);
+    EXPECT_NEAR(HMM_PowerF(2.0f, -2.5f), 0.176777f, 0.0001f);
 }
 
 TEST(ScalarMath, Lerp)


### PR DESCRIPTION
Resolves #99 by silencing float comparison warnings. This can be merged into the 1.0 branch.