### PR TITLE
Add ability to customize HMM_ prefix

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -33,6 +33,16 @@
 
   =============================================================================
 
+  If you would prefer not to use the HMM_ prefix on function names, you can
+
+  #define HMM_PREFIX
+
+  To use a custom prefix instead, you can
+
+  #define HMM_PREFIX(name) YOUR_PREFIX_##name
+
+  =============================================================================
+
   To use HandmadeMath without the CRT, you MUST
 
      #define HMM_SINF MySinF

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -199,6 +199,10 @@ extern "C"
 #define HMM_MOD(a, m) ((a) % (m)) >= 0 ? ((a) % (m)) : (((a) % (m)) + (m))
 #define HMM_SQUARE(x) ((x) * (x))
 
+#ifndef HMM_PREFIX
+#define HMM_PREFIX(name) HMM_##name
+#endif
+
 typedef union hmm_vec2
 {
     struct
@@ -410,7 +414,7 @@ typedef hmm_mat4 hmm_m4;
  */
 
 COVERAGE(HMM_SinF, 1)
-HMM_INLINE float HMM_SinF(float Radians)
+HMM_INLINE float HMM_PREFIX(SinF)(float Radians)
 {
     ASSERT_COVERED(HMM_SinF);
 
@@ -420,7 +424,7 @@ HMM_INLINE float HMM_SinF(float Radians)
 }
 
 COVERAGE(HMM_CosF, 1)
-HMM_INLINE float HMM_CosF(float Radians)
+HMM_INLINE float HMM_PREFIX(CosF)(float Radians)
 {
     ASSERT_COVERED(HMM_CosF);
 
@@ -430,7 +434,7 @@ HMM_INLINE float HMM_CosF(float Radians)
 }
 
 COVERAGE(HMM_TanF, 1)
-HMM_INLINE float HMM_TanF(float Radians)
+HMM_INLINE float HMM_PREFIX(TanF)(float Radians)
 {
     ASSERT_COVERED(HMM_TanF);
 
@@ -440,7 +444,7 @@ HMM_INLINE float HMM_TanF(float Radians)
 }
 
 COVERAGE(HMM_ACosF, 1)
-HMM_INLINE float HMM_ACosF(float Radians)
+HMM_INLINE float HMM_PREFIX(ACosF)(float Radians)
 {
     ASSERT_COVERED(HMM_ACosF);
 
@@ -450,7 +454,7 @@ HMM_INLINE float HMM_ACosF(float Radians)
 }
 
 COVERAGE(HMM_ATanF, 1)
-HMM_INLINE float HMM_ATanF(float Radians)
+HMM_INLINE float HMM_PREFIX(ATanF)(float Radians)
 {
     ASSERT_COVERED(HMM_ATanF);
 
@@ -460,7 +464,7 @@ HMM_INLINE float HMM_ATanF(float Radians)
 }
 
 COVERAGE(HMM_ATan2F, 1)
-HMM_INLINE float HMM_ATan2F(float Left, float Right)
+HMM_INLINE float HMM_PREFIX(ATan2F)(float Left, float Right)
 {
     ASSERT_COVERED(HMM_ATan2F);
 
@@ -470,7 +474,7 @@ HMM_INLINE float HMM_ATan2F(float Left, float Right)
 }
 
 COVERAGE(HMM_ExpF, 1)
-HMM_INLINE float HMM_ExpF(float Float)
+HMM_INLINE float HMM_PREFIX(ExpF)(float Float)
 {
     ASSERT_COVERED(HMM_ExpF);
 
@@ -480,7 +484,7 @@ HMM_INLINE float HMM_ExpF(float Float)
 }
 
 COVERAGE(HMM_LogF, 1)
-HMM_INLINE float HMM_LogF(float Float)
+HMM_INLINE float HMM_PREFIX(LogF)(float Float)
 {
     ASSERT_COVERED(HMM_LogF);
 
@@ -490,7 +494,7 @@ HMM_INLINE float HMM_LogF(float Float)
 }
 
 COVERAGE(HMM_SquareRootF, 1)
-HMM_INLINE float HMM_SquareRootF(float Float)
+HMM_INLINE float HMM_PREFIX(SquareRootF)(float Float)
 {
     ASSERT_COVERED(HMM_SquareRootF);
 
@@ -508,7 +512,7 @@ HMM_INLINE float HMM_SquareRootF(float Float)
 }
 
 COVERAGE(HMM_RSquareRootF, 1)
-HMM_INLINE float HMM_RSquareRootF(float Float)
+HMM_INLINE float HMM_PREFIX(RSquareRootF)(float Float)
 {
     ASSERT_COVERED(HMM_RSquareRootF);
 
@@ -519,16 +523,16 @@ HMM_INLINE float HMM_RSquareRootF(float Float)
     __m128 Out = _mm_rsqrt_ss(In);
     Result = _mm_cvtss_f32(Out);
 #else
-    Result = 1.0f/HMM_SquareRootF(Float);
+    Result = 1.0f/HMM_PREFIX(SquareRootF)(Float);
 #endif
 
     return(Result);
 }
 
-HMM_EXTERN float HMM_Power(float Base, int Exponent);
+HMM_EXTERN float HMM_PREFIX(Power)(float Base, int Exponent);
 
 COVERAGE(HMM_PowerF, 1)
-HMM_INLINE float HMM_PowerF(float Base, float Exponent)
+HMM_INLINE float HMM_PREFIX(PowerF)(float Base, float Exponent)
 {
     ASSERT_COVERED(HMM_PowerF);
 
@@ -543,7 +547,7 @@ HMM_INLINE float HMM_PowerF(float Base, float Exponent)
  */
 
 COVERAGE(HMM_ToRadians, 1)
-HMM_INLINE float HMM_ToRadians(float Degrees)
+HMM_INLINE float HMM_PREFIX(ToRadians)(float Degrees)
 {
     ASSERT_COVERED(HMM_ToRadians);
 
@@ -553,7 +557,7 @@ HMM_INLINE float HMM_ToRadians(float Degrees)
 }
 
 COVERAGE(HMM_Lerp, 1)
-HMM_INLINE float HMM_Lerp(float A, float Time, float B)
+HMM_INLINE float HMM_PREFIX(Lerp)(float A, float Time, float B)
 {
     ASSERT_COVERED(HMM_Lerp);
 
@@ -563,7 +567,7 @@ HMM_INLINE float HMM_Lerp(float A, float Time, float B)
 }
 
 COVERAGE(HMM_Clamp, 1)
-HMM_INLINE float HMM_Clamp(float Min, float Value, float Max)
+HMM_INLINE float HMM_PREFIX(Clamp)(float Min, float Value, float Max)
 {
     ASSERT_COVERED(HMM_Clamp);
 
@@ -587,7 +591,7 @@ HMM_INLINE float HMM_Clamp(float Min, float Value, float Max)
  */
 
 COVERAGE(HMM_Vec2, 1)
-HMM_INLINE hmm_vec2 HMM_Vec2(float X, float Y)
+HMM_INLINE hmm_vec2 HMM_PREFIX(Vec2)(float X, float Y)
 {
     ASSERT_COVERED(HMM_Vec2);
 
@@ -600,7 +604,7 @@ HMM_INLINE hmm_vec2 HMM_Vec2(float X, float Y)
 }
 
 COVERAGE(HMM_Vec2i, 1)
-HMM_INLINE hmm_vec2 HMM_Vec2i(int X, int Y)
+HMM_INLINE hmm_vec2 HMM_PREFIX(Vec2i)(int X, int Y)
 {
     ASSERT_COVERED(HMM_Vec2i);
 
@@ -613,7 +617,7 @@ HMM_INLINE hmm_vec2 HMM_Vec2i(int X, int Y)
 }
 
 COVERAGE(HMM_Vec3, 1)
-HMM_INLINE hmm_vec3 HMM_Vec3(float X, float Y, float Z)
+HMM_INLINE hmm_vec3 HMM_PREFIX(Vec3)(float X, float Y, float Z)
 {
     ASSERT_COVERED(HMM_Vec3);
 
@@ -627,7 +631,7 @@ HMM_INLINE hmm_vec3 HMM_Vec3(float X, float Y, float Z)
 }
 
 COVERAGE(HMM_Vec3i, 1)
-HMM_INLINE hmm_vec3 HMM_Vec3i(int X, int Y, int Z)
+HMM_INLINE hmm_vec3 HMM_PREFIX(Vec3i)(int X, int Y, int Z)
 {
     ASSERT_COVERED(HMM_Vec3i);
 
@@ -641,7 +645,7 @@ HMM_INLINE hmm_vec3 HMM_Vec3i(int X, int Y, int Z)
 }
 
 COVERAGE(HMM_Vec4, 1)
-HMM_INLINE hmm_vec4 HMM_Vec4(float X, float Y, float Z, float W)
+HMM_INLINE hmm_vec4 HMM_PREFIX(Vec4)(float X, float Y, float Z, float W)
 {
     ASSERT_COVERED(HMM_Vec4);
 
@@ -660,7 +664,7 @@ HMM_INLINE hmm_vec4 HMM_Vec4(float X, float Y, float Z, float W)
 }
 
 COVERAGE(HMM_Vec4i, 1)
-HMM_INLINE hmm_vec4 HMM_Vec4i(int X, int Y, int Z, int W)
+HMM_INLINE hmm_vec4 HMM_PREFIX(Vec4i)(int X, int Y, int Z, int W)
 {
     ASSERT_COVERED(HMM_Vec4i);
 
@@ -679,7 +683,7 @@ HMM_INLINE hmm_vec4 HMM_Vec4i(int X, int Y, int Z, int W)
 }
 
 COVERAGE(HMM_Vec4v, 1)
-HMM_INLINE hmm_vec4 HMM_Vec4v(hmm_vec3 Vector, float W)
+HMM_INLINE hmm_vec4 HMM_PREFIX(Vec4v)(hmm_vec3 Vector, float W)
 {
     ASSERT_COVERED(HMM_Vec4v);
 
@@ -701,7 +705,7 @@ HMM_INLINE hmm_vec4 HMM_Vec4v(hmm_vec3 Vector, float W)
  */
 
 COVERAGE(HMM_AddVec2, 1)
-HMM_INLINE hmm_vec2 HMM_AddVec2(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 HMM_PREFIX(AddVec2)(hmm_vec2 Left, hmm_vec2 Right)
 {
     ASSERT_COVERED(HMM_AddVec2);
 
@@ -714,7 +718,7 @@ HMM_INLINE hmm_vec2 HMM_AddVec2(hmm_vec2 Left, hmm_vec2 Right)
 }
 
 COVERAGE(HMM_AddVec3, 1)
-HMM_INLINE hmm_vec3 HMM_AddVec3(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 HMM_PREFIX(AddVec3)(hmm_vec3 Left, hmm_vec3 Right)
 {
     ASSERT_COVERED(HMM_AddVec3);
 
@@ -728,7 +732,7 @@ HMM_INLINE hmm_vec3 HMM_AddVec3(hmm_vec3 Left, hmm_vec3 Right)
 }
 
 COVERAGE(HMM_AddVec4, 1)
-HMM_INLINE hmm_vec4 HMM_AddVec4(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 HMM_PREFIX(AddVec4)(hmm_vec4 Left, hmm_vec4 Right)
 {
     ASSERT_COVERED(HMM_AddVec4);
 
@@ -747,7 +751,7 @@ HMM_INLINE hmm_vec4 HMM_AddVec4(hmm_vec4 Left, hmm_vec4 Right)
 }
 
 COVERAGE(HMM_SubtractVec2, 1)
-HMM_INLINE hmm_vec2 HMM_SubtractVec2(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 HMM_PREFIX(SubtractVec2)(hmm_vec2 Left, hmm_vec2 Right)
 {
     ASSERT_COVERED(HMM_SubtractVec2);
 
@@ -760,7 +764,7 @@ HMM_INLINE hmm_vec2 HMM_SubtractVec2(hmm_vec2 Left, hmm_vec2 Right)
 }
 
 COVERAGE(HMM_SubtractVec3, 1)
-HMM_INLINE hmm_vec3 HMM_SubtractVec3(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 HMM_PREFIX(SubtractVec3)(hmm_vec3 Left, hmm_vec3 Right)
 {
     ASSERT_COVERED(HMM_SubtractVec3);
 
@@ -774,7 +778,7 @@ HMM_INLINE hmm_vec3 HMM_SubtractVec3(hmm_vec3 Left, hmm_vec3 Right)
 }
 
 COVERAGE(HMM_SubtractVec4, 1)
-HMM_INLINE hmm_vec4 HMM_SubtractVec4(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 HMM_PREFIX(SubtractVec4)(hmm_vec4 Left, hmm_vec4 Right)
 {
     ASSERT_COVERED(HMM_SubtractVec4);
 
@@ -793,7 +797,7 @@ HMM_INLINE hmm_vec4 HMM_SubtractVec4(hmm_vec4 Left, hmm_vec4 Right)
 }
 
 COVERAGE(HMM_MultiplyVec2, 1)
-HMM_INLINE hmm_vec2 HMM_MultiplyVec2(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 HMM_PREFIX(MultiplyVec2)(hmm_vec2 Left, hmm_vec2 Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec2);
 
@@ -806,7 +810,7 @@ HMM_INLINE hmm_vec2 HMM_MultiplyVec2(hmm_vec2 Left, hmm_vec2 Right)
 }
 
 COVERAGE(HMM_MultiplyVec2f, 1)
-HMM_INLINE hmm_vec2 HMM_MultiplyVec2f(hmm_vec2 Left, float Right)
+HMM_INLINE hmm_vec2 HMM_PREFIX(MultiplyVec2f)(hmm_vec2 Left, float Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec2f);
 
@@ -819,7 +823,7 @@ HMM_INLINE hmm_vec2 HMM_MultiplyVec2f(hmm_vec2 Left, float Right)
 }
 
 COVERAGE(HMM_MultiplyVec3, 1)
-HMM_INLINE hmm_vec3 HMM_MultiplyVec3(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 HMM_PREFIX(MultiplyVec3)(hmm_vec3 Left, hmm_vec3 Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec3);
 
@@ -833,7 +837,7 @@ HMM_INLINE hmm_vec3 HMM_MultiplyVec3(hmm_vec3 Left, hmm_vec3 Right)
 }
 
 COVERAGE(HMM_MultiplyVec3f, 1)
-HMM_INLINE hmm_vec3 HMM_MultiplyVec3f(hmm_vec3 Left, float Right)
+HMM_INLINE hmm_vec3 HMM_PREFIX(MultiplyVec3f)(hmm_vec3 Left, float Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec3f);
 
@@ -847,7 +851,7 @@ HMM_INLINE hmm_vec3 HMM_MultiplyVec3f(hmm_vec3 Left, float Right)
 }
 
 COVERAGE(HMM_MultiplyVec4, 1)
-HMM_INLINE hmm_vec4 HMM_MultiplyVec4(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 HMM_PREFIX(MultiplyVec4)(hmm_vec4 Left, hmm_vec4 Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec4);
 
@@ -866,7 +870,7 @@ HMM_INLINE hmm_vec4 HMM_MultiplyVec4(hmm_vec4 Left, hmm_vec4 Right)
 }
 
 COVERAGE(HMM_MultiplyVec4f, 1)
-HMM_INLINE hmm_vec4 HMM_MultiplyVec4f(hmm_vec4 Left, float Right)
+HMM_INLINE hmm_vec4 HMM_PREFIX(MultiplyVec4f)(hmm_vec4 Left, float Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec4f);
 
@@ -886,7 +890,7 @@ HMM_INLINE hmm_vec4 HMM_MultiplyVec4f(hmm_vec4 Left, float Right)
 }
 
 COVERAGE(HMM_DivideVec2, 1)
-HMM_INLINE hmm_vec2 HMM_DivideVec2(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 HMM_PREFIX(DivideVec2)(hmm_vec2 Left, hmm_vec2 Right)
 {
     ASSERT_COVERED(HMM_DivideVec2);
 
@@ -899,7 +903,7 @@ HMM_INLINE hmm_vec2 HMM_DivideVec2(hmm_vec2 Left, hmm_vec2 Right)
 }
 
 COVERAGE(HMM_DivideVec2f, 1)
-HMM_INLINE hmm_vec2 HMM_DivideVec2f(hmm_vec2 Left, float Right)
+HMM_INLINE hmm_vec2 HMM_PREFIX(DivideVec2f)(hmm_vec2 Left, float Right)
 {
     ASSERT_COVERED(HMM_DivideVec2f);
 
@@ -912,7 +916,7 @@ HMM_INLINE hmm_vec2 HMM_DivideVec2f(hmm_vec2 Left, float Right)
 }
 
 COVERAGE(HMM_DivideVec3, 1)
-HMM_INLINE hmm_vec3 HMM_DivideVec3(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 HMM_PREFIX(DivideVec3)(hmm_vec3 Left, hmm_vec3 Right)
 {
     ASSERT_COVERED(HMM_DivideVec3);
 
@@ -926,7 +930,7 @@ HMM_INLINE hmm_vec3 HMM_DivideVec3(hmm_vec3 Left, hmm_vec3 Right)
 }
 
 COVERAGE(HMM_DivideVec3f, 1)
-HMM_INLINE hmm_vec3 HMM_DivideVec3f(hmm_vec3 Left, float Right)
+HMM_INLINE hmm_vec3 HMM_PREFIX(DivideVec3f)(hmm_vec3 Left, float Right)
 {
     ASSERT_COVERED(HMM_DivideVec3f);
 
@@ -940,7 +944,7 @@ HMM_INLINE hmm_vec3 HMM_DivideVec3f(hmm_vec3 Left, float Right)
 }
 
 COVERAGE(HMM_DivideVec4, 1)
-HMM_INLINE hmm_vec4 HMM_DivideVec4(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 HMM_PREFIX(DivideVec4)(hmm_vec4 Left, hmm_vec4 Right)
 {
     ASSERT_COVERED(HMM_DivideVec4);
 
@@ -959,7 +963,7 @@ HMM_INLINE hmm_vec4 HMM_DivideVec4(hmm_vec4 Left, hmm_vec4 Right)
 }
 
 COVERAGE(HMM_DivideVec4f, 1)
-HMM_INLINE hmm_vec4 HMM_DivideVec4f(hmm_vec4 Left, float Right)
+HMM_INLINE hmm_vec4 HMM_PREFIX(DivideVec4f)(hmm_vec4 Left, float Right)
 {
     ASSERT_COVERED(HMM_DivideVec4f);
 
@@ -979,7 +983,7 @@ HMM_INLINE hmm_vec4 HMM_DivideVec4f(hmm_vec4 Left, float Right)
 }
 
 COVERAGE(HMM_EqualsVec2, 1)
-HMM_INLINE hmm_bool HMM_EqualsVec2(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_bool HMM_PREFIX(EqualsVec2)(hmm_vec2 Left, hmm_vec2 Right)
 {
     ASSERT_COVERED(HMM_EqualsVec2);
 
@@ -989,7 +993,7 @@ HMM_INLINE hmm_bool HMM_EqualsVec2(hmm_vec2 Left, hmm_vec2 Right)
 }
 
 COVERAGE(HMM_EqualsVec3, 1)
-HMM_INLINE hmm_bool HMM_EqualsVec3(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_bool HMM_PREFIX(EqualsVec3)(hmm_vec3 Left, hmm_vec3 Right)
 {
     ASSERT_COVERED(HMM_EqualsVec3);
 
@@ -999,7 +1003,7 @@ HMM_INLINE hmm_bool HMM_EqualsVec3(hmm_vec3 Left, hmm_vec3 Right)
 }
 
 COVERAGE(HMM_EqualsVec4, 1)
-HMM_INLINE hmm_bool HMM_EqualsVec4(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_bool HMM_PREFIX(EqualsVec4)(hmm_vec4 Left, hmm_vec4 Right)
 {
     ASSERT_COVERED(HMM_EqualsVec4);
 
@@ -1009,7 +1013,7 @@ HMM_INLINE hmm_bool HMM_EqualsVec4(hmm_vec4 Left, hmm_vec4 Right)
 }
 
 COVERAGE(HMM_DotVec2, 1)
-HMM_INLINE float HMM_DotVec2(hmm_vec2 VecOne, hmm_vec2 VecTwo)
+HMM_INLINE float HMM_PREFIX(DotVec2)(hmm_vec2 VecOne, hmm_vec2 VecTwo)
 {
     ASSERT_COVERED(HMM_DotVec2);
 
@@ -1019,7 +1023,7 @@ HMM_INLINE float HMM_DotVec2(hmm_vec2 VecOne, hmm_vec2 VecTwo)
 }
 
 COVERAGE(HMM_DotVec3, 1)
-HMM_INLINE float HMM_DotVec3(hmm_vec3 VecOne, hmm_vec3 VecTwo)
+HMM_INLINE float HMM_PREFIX(DotVec3)(hmm_vec3 VecOne, hmm_vec3 VecTwo)
 {
     ASSERT_COVERED(HMM_DotVec3);
 
@@ -1029,7 +1033,7 @@ HMM_INLINE float HMM_DotVec3(hmm_vec3 VecOne, hmm_vec3 VecTwo)
 }
 
 COVERAGE(HMM_DotVec4, 1)
-HMM_INLINE float HMM_DotVec4(hmm_vec4 VecOne, hmm_vec4 VecTwo)
+HMM_INLINE float HMM_PREFIX(DotVec4)(hmm_vec4 VecOne, hmm_vec4 VecTwo)
 {
     ASSERT_COVERED(HMM_DotVec4);
 
@@ -1053,7 +1057,7 @@ HMM_INLINE float HMM_DotVec4(hmm_vec4 VecOne, hmm_vec4 VecTwo)
 }
 
 COVERAGE(HMM_Cross, 1)
-HMM_INLINE hmm_vec3 HMM_Cross(hmm_vec3 VecOne, hmm_vec3 VecTwo)
+HMM_INLINE hmm_vec3 HMM_PREFIX(Cross)(hmm_vec3 VecOne, hmm_vec3 VecTwo)
 {
     ASSERT_COVERED(HMM_Cross);
 
@@ -1072,73 +1076,73 @@ HMM_INLINE hmm_vec3 HMM_Cross(hmm_vec3 VecOne, hmm_vec3 VecTwo)
  */
 
 COVERAGE(HMM_LengthSquaredVec2, 1)
-HMM_INLINE float HMM_LengthSquaredVec2(hmm_vec2 A)
+HMM_INLINE float HMM_PREFIX(LengthSquaredVec2)(hmm_vec2 A)
 {
     ASSERT_COVERED(HMM_LengthSquaredVec2);
 
-    float Result = HMM_DotVec2(A, A);
+    float Result = HMM_PREFIX(DotVec2)(A, A);
 
     return (Result);
 }
 
 COVERAGE(HMM_LengthSquaredVec3, 1)
-HMM_INLINE float HMM_LengthSquaredVec3(hmm_vec3 A)
+HMM_INLINE float HMM_PREFIX(LengthSquaredVec3)(hmm_vec3 A)
 {
     ASSERT_COVERED(HMM_LengthSquaredVec3);
 
-    float Result = HMM_DotVec3(A, A);
+    float Result = HMM_PREFIX(DotVec3)(A, A);
 
     return (Result);
 }
 
 COVERAGE(HMM_LengthSquaredVec4, 1)
-HMM_INLINE float HMM_LengthSquaredVec4(hmm_vec4 A)
+HMM_INLINE float HMM_PREFIX(LengthSquaredVec4)(hmm_vec4 A)
 {
     ASSERT_COVERED(HMM_LengthSquaredVec4);
 
-    float Result = HMM_DotVec4(A, A);
+    float Result = HMM_PREFIX(DotVec4)(A, A);
 
     return (Result);
 }
 
 COVERAGE(HMM_LengthVec2, 1)
-HMM_INLINE float HMM_LengthVec2(hmm_vec2 A)
+HMM_INLINE float HMM_PREFIX(LengthVec2)(hmm_vec2 A)
 {
     ASSERT_COVERED(HMM_LengthVec2);
 
-    float Result = HMM_SquareRootF(HMM_LengthSquaredVec2(A));
+    float Result = HMM_PREFIX(SquareRootF)(HMM_PREFIX(LengthSquaredVec2)(A));
 
     return (Result);
 }
 
 COVERAGE(HMM_LengthVec3, 1)
-HMM_INLINE float HMM_LengthVec3(hmm_vec3 A)
+HMM_INLINE float HMM_PREFIX(LengthVec3)(hmm_vec3 A)
 {
     ASSERT_COVERED(HMM_LengthVec3);
 
-    float Result = HMM_SquareRootF(HMM_LengthSquaredVec3(A));
+    float Result = HMM_PREFIX(SquareRootF)(HMM_PREFIX(LengthSquaredVec3)(A));
 
     return (Result);
 }
 
 COVERAGE(HMM_LengthVec4, 1)
-HMM_INLINE float HMM_LengthVec4(hmm_vec4 A)
+HMM_INLINE float HMM_PREFIX(LengthVec4)(hmm_vec4 A)
 {
     ASSERT_COVERED(HMM_LengthVec4);
 
-    float Result = HMM_SquareRootF(HMM_LengthSquaredVec4(A));
+    float Result = HMM_PREFIX(SquareRootF)(HMM_PREFIX(LengthSquaredVec4)(A));
 
     return(Result);
 }
 
 COVERAGE(HMM_NormalizeVec2, 2)
-HMM_INLINE hmm_vec2 HMM_NormalizeVec2(hmm_vec2 A)
+HMM_INLINE hmm_vec2 HMM_PREFIX(NormalizeVec2)(hmm_vec2 A)
 {
     ASSERT_COVERED(HMM_NormalizeVec2);
 
     hmm_vec2 Result = {0};
 
-    float VectorLength = HMM_LengthVec2(A);
+    float VectorLength = HMM_PREFIX(LengthVec2)(A);
 
     /* NOTE(kiljacken): We need a zero check to not divide-by-zero */
     if (VectorLength != 0.0f)
@@ -1153,13 +1157,13 @@ HMM_INLINE hmm_vec2 HMM_NormalizeVec2(hmm_vec2 A)
 }
 
 COVERAGE(HMM_NormalizeVec3, 2)
-HMM_INLINE hmm_vec3 HMM_NormalizeVec3(hmm_vec3 A)
+HMM_INLINE hmm_vec3 HMM_PREFIX(NormalizeVec3)(hmm_vec3 A)
 {
     ASSERT_COVERED(HMM_NormalizeVec3);
 
     hmm_vec3 Result = {0};
 
-    float VectorLength = HMM_LengthVec3(A);
+    float VectorLength = HMM_PREFIX(LengthVec3)(A);
 
     /* NOTE(kiljacken): We need a zero check to not divide-by-zero */
     if (VectorLength != 0.0f)
@@ -1175,13 +1179,13 @@ HMM_INLINE hmm_vec3 HMM_NormalizeVec3(hmm_vec3 A)
 }
 
 COVERAGE(HMM_NormalizeVec4, 2)
-HMM_INLINE hmm_vec4 HMM_NormalizeVec4(hmm_vec4 A)
+HMM_INLINE hmm_vec4 HMM_PREFIX(NormalizeVec4)(hmm_vec4 A)
 {
     ASSERT_COVERED(HMM_NormalizeVec4);
 
     hmm_vec4 Result = {0};
 
-    float VectorLength = HMM_LengthVec4(A);
+    float VectorLength = HMM_PREFIX(LengthVec4)(A);
 
     /* NOTE(kiljacken): We need a zero check to not divide-by-zero */
     if (VectorLength != 0.0f)
@@ -1205,27 +1209,27 @@ HMM_INLINE hmm_vec4 HMM_NormalizeVec4(hmm_vec4 A)
 }
 
 COVERAGE(HMM_FastNormalizeVec2, 1)
-HMM_INLINE hmm_vec2 HMM_FastNormalizeVec2(hmm_vec2 A)
+HMM_INLINE hmm_vec2 HMM_PREFIX(FastNormalizeVec2)(hmm_vec2 A)
 {
     ASSERT_COVERED(HMM_FastNormalizeVec2);
 
-    return HMM_MultiplyVec2f(A, HMM_RSquareRootF(HMM_DotVec2(A, A)));
+    return HMM_PREFIX(MultiplyVec2f)(A, HMM_PREFIX(RSquareRootF)(HMM_PREFIX(DotVec2)(A, A)));
 }
 
 COVERAGE(HMM_FastNormalizeVec3, 1)
-HMM_INLINE hmm_vec3 HMM_FastNormalizeVec3(hmm_vec3 A)
+HMM_INLINE hmm_vec3 HMM_PREFIX(FastNormalizeVec3)(hmm_vec3 A)
 {
     ASSERT_COVERED(HMM_FastNormalizeVec3);
 
-    return HMM_MultiplyVec3f(A, HMM_RSquareRootF(HMM_DotVec3(A, A)));
+    return HMM_PREFIX(MultiplyVec3f)(A, HMM_PREFIX(RSquareRootF)(HMM_PREFIX(DotVec3)(A, A)));
 }
 
 COVERAGE(HMM_FastNormalizeVec4, 1)
-HMM_INLINE hmm_vec4 HMM_FastNormalizeVec4(hmm_vec4 A)
+HMM_INLINE hmm_vec4 HMM_PREFIX(FastNormalizeVec4)(hmm_vec4 A)
 {
     ASSERT_COVERED(HMM_FastNormalizeVec4);
 
-    return HMM_MultiplyVec4f(A, HMM_RSquareRootF(HMM_DotVec4(A, A)));
+    return HMM_PREFIX(MultiplyVec4f)(A, HMM_PREFIX(RSquareRootF)(HMM_PREFIX(DotVec4)(A, A)));
 }
 
 
@@ -1235,7 +1239,7 @@ HMM_INLINE hmm_vec4 HMM_FastNormalizeVec4(hmm_vec4 A)
 
 #ifdef HANDMADE_MATH__USE_SSE
 COVERAGE(HMM_LinearCombineSSE, 1)
-HMM_INLINE __m128 HMM_LinearCombineSSE(__m128 Left, hmm_mat4 Right)
+HMM_INLINE __m128 HMM_PREFIX(LinearCombineSSE)(__m128 Left, hmm_mat4 Right)
 {
     ASSERT_COVERED(HMM_LinearCombineSSE);
 
@@ -1255,7 +1259,7 @@ HMM_INLINE __m128 HMM_LinearCombineSSE(__m128 Left, hmm_mat4 Right)
  */
 
 COVERAGE(HMM_Mat4, 1)
-HMM_INLINE hmm_mat4 HMM_Mat4(void)
+HMM_INLINE hmm_mat4 HMM_PREFIX(Mat4)(void)
 {
     ASSERT_COVERED(HMM_Mat4);
 
@@ -1265,11 +1269,11 @@ HMM_INLINE hmm_mat4 HMM_Mat4(void)
 }
 
 COVERAGE(HMM_Mat4d, 1)
-HMM_INLINE hmm_mat4 HMM_Mat4d(float Diagonal)
+HMM_INLINE hmm_mat4 HMM_PREFIX(Mat4d)(float Diagonal)
 {
     ASSERT_COVERED(HMM_Mat4d);
 
-    hmm_mat4 Result = HMM_Mat4();
+    hmm_mat4 Result = HMM_PREFIX(Mat4)();
 
     Result.Elements[0][0] = Diagonal;
     Result.Elements[1][1] = Diagonal;
@@ -1281,7 +1285,7 @@ HMM_INLINE hmm_mat4 HMM_Mat4d(float Diagonal)
 
 #ifdef HANDMADE_MATH__USE_SSE
 COVERAGE(HMM_Transpose, 1)
-HMM_INLINE hmm_mat4 HMM_Transpose(hmm_mat4 Matrix)
+HMM_INLINE hmm_mat4 HMM_PREFIX(Transpose)(hmm_mat4 Matrix)
 {
     ASSERT_COVERED(HMM_Transpose);
 
@@ -1292,12 +1296,12 @@ HMM_INLINE hmm_mat4 HMM_Transpose(hmm_mat4 Matrix)
     return (Result);
 }
 #else
-HMM_EXTERN hmm_mat4 HMM_Transpose(hmm_mat4 Matrix);
+HMM_EXTERN hmm_mat4 HMM_PREFIX(Transpose)(hmm_mat4 Matrix);
 #endif
 
 #ifdef HANDMADE_MATH__USE_SSE
 COVERAGE(HMM_AddMat4, 1)
-HMM_INLINE hmm_mat4 HMM_AddMat4(hmm_mat4 Left, hmm_mat4 Right)
+HMM_INLINE hmm_mat4 HMM_PREFIX(AddMat4)(hmm_mat4 Left, hmm_mat4 Right)
 {
     ASSERT_COVERED(HMM_AddMat4);
 
@@ -1311,12 +1315,12 @@ HMM_INLINE hmm_mat4 HMM_AddMat4(hmm_mat4 Left, hmm_mat4 Right)
     return (Result);
 }
 #else
-HMM_EXTERN hmm_mat4 HMM_AddMat4(hmm_mat4 Left, hmm_mat4 Right);
+HMM_EXTERN hmm_mat4 HMM_PREFIX(AddMat4)(hmm_mat4 Left, hmm_mat4 Right);
 #endif
 
 #ifdef HANDMADE_MATH__USE_SSE
 COVERAGE(HMM_SubtractMat4, 1)
-HMM_INLINE hmm_mat4 HMM_SubtractMat4(hmm_mat4 Left, hmm_mat4 Right)
+HMM_INLINE hmm_mat4 HMM_PREFIX(SubtractMat4)(hmm_mat4 Left, hmm_mat4 Right)
 {
     ASSERT_COVERED(HMM_SubtractMat4);
 
@@ -1330,14 +1334,14 @@ HMM_INLINE hmm_mat4 HMM_SubtractMat4(hmm_mat4 Left, hmm_mat4 Right)
     return (Result);
 }
 #else
-HMM_EXTERN hmm_mat4 HMM_SubtractMat4(hmm_mat4 Left, hmm_mat4 Right);
+HMM_EXTERN hmm_mat4 HMM_PREFIX(SubtractMat4)(hmm_mat4 Left, hmm_mat4 Right);
 #endif
 
-HMM_EXTERN hmm_mat4 HMM_MultiplyMat4(hmm_mat4 Left, hmm_mat4 Right);
+HMM_EXTERN hmm_mat4 HMM_PREFIX(MultiplyMat4)(hmm_mat4 Left, hmm_mat4 Right);
 
 #ifdef HANDMADE_MATH__USE_SSE
 COVERAGE(HMM_MultiplyMat4f, 1)
-HMM_INLINE hmm_mat4 HMM_MultiplyMat4f(hmm_mat4 Matrix, float Scalar)
+HMM_INLINE hmm_mat4 HMM_PREFIX(MultiplyMat4f)(hmm_mat4 Matrix, float Scalar)
 {
     ASSERT_COVERED(HMM_MultiplyMat4f);
 
@@ -1352,14 +1356,14 @@ HMM_INLINE hmm_mat4 HMM_MultiplyMat4f(hmm_mat4 Matrix, float Scalar)
     return (Result);
 }
 #else
-HMM_EXTERN hmm_mat4 HMM_MultiplyMat4f(hmm_mat4 Matrix, float Scalar);
+HMM_EXTERN hmm_mat4 HMM_PREFIX(MultiplyMat4f)(hmm_mat4 Matrix, float Scalar);
 #endif
 
-HMM_EXTERN hmm_vec4 HMM_MultiplyMat4ByVec4(hmm_mat4 Matrix, hmm_vec4 Vector);
+HMM_EXTERN hmm_vec4 HMM_PREFIX(MultiplyMat4ByVec4)(hmm_mat4 Matrix, hmm_vec4 Vector);
 
 #ifdef HANDMADE_MATH__USE_SSE
 COVERAGE(HMM_DivideMat4f, 1)
-HMM_INLINE hmm_mat4 HMM_DivideMat4f(hmm_mat4 Matrix, float Scalar)
+HMM_INLINE hmm_mat4 HMM_PREFIX(DivideMat4f)(hmm_mat4 Matrix, float Scalar)
 {
     ASSERT_COVERED(HMM_DivideMat4f);
 
@@ -1374,7 +1378,7 @@ HMM_INLINE hmm_mat4 HMM_DivideMat4f(hmm_mat4 Matrix, float Scalar)
     return (Result);
 }
 #else
-HMM_EXTERN hmm_mat4 HMM_DivideMat4f(hmm_mat4 Matrix, float Scalar);
+HMM_EXTERN hmm_mat4 HMM_PREFIX(DivideMat4f)(hmm_mat4 Matrix, float Scalar);
 #endif
 
 
@@ -1383,11 +1387,11 @@ HMM_EXTERN hmm_mat4 HMM_DivideMat4f(hmm_mat4 Matrix, float Scalar);
  */
 
 COVERAGE(HMM_Orthographic, 1)
-HMM_INLINE hmm_mat4 HMM_Orthographic(float Left, float Right, float Bottom, float Top, float Near, float Far)
+HMM_INLINE hmm_mat4 HMM_PREFIX(Orthographic)(float Left, float Right, float Bottom, float Top, float Near, float Far)
 {
     ASSERT_COVERED(HMM_Orthographic);
 
-    hmm_mat4 Result = HMM_Mat4();
+    hmm_mat4 Result = HMM_PREFIX(Mat4)();
 
     Result.Elements[0][0] = 2.0f / (Right - Left);
     Result.Elements[1][1] = 2.0f / (Top - Bottom);
@@ -1402,15 +1406,15 @@ HMM_INLINE hmm_mat4 HMM_Orthographic(float Left, float Right, float Bottom, floa
 }
 
 COVERAGE(HMM_Perspective, 1)
-HMM_INLINE hmm_mat4 HMM_Perspective(float FOV, float AspectRatio, float Near, float Far)
+HMM_INLINE hmm_mat4 HMM_PREFIX(Perspective)(float FOV, float AspectRatio, float Near, float Far)
 {
     ASSERT_COVERED(HMM_Perspective);
 
-    hmm_mat4 Result = HMM_Mat4();
+    hmm_mat4 Result = HMM_PREFIX(Mat4)();
 
     // See https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml
 
-    float Cotangent = 1.0f / HMM_TanF(FOV * (HMM_PI32 / 360.0f));
+    float Cotangent = 1.0f / HMM_PREFIX(TanF)(FOV * (HMM_PI32 / 360.0f));
 
     Result.Elements[0][0] = Cotangent / AspectRatio;
     Result.Elements[1][1] = Cotangent;
@@ -1423,11 +1427,11 @@ HMM_INLINE hmm_mat4 HMM_Perspective(float FOV, float AspectRatio, float Near, fl
 }
 
 COVERAGE(HMM_Translate, 1)
-HMM_INLINE hmm_mat4 HMM_Translate(hmm_vec3 Translation)
+HMM_INLINE hmm_mat4 HMM_PREFIX(Translate)(hmm_vec3 Translation)
 {
     ASSERT_COVERED(HMM_Translate);
 
-    hmm_mat4 Result = HMM_Mat4d(1.0f);
+    hmm_mat4 Result = HMM_PREFIX(Mat4d)(1.0f);
 
     Result.Elements[3][0] = Translation.X;
     Result.Elements[3][1] = Translation.Y;
@@ -1436,14 +1440,14 @@ HMM_INLINE hmm_mat4 HMM_Translate(hmm_vec3 Translation)
     return (Result);
 }
 
-HMM_EXTERN hmm_mat4 HMM_Rotate(float Angle, hmm_vec3 Axis);
+HMM_EXTERN hmm_mat4 HMM_PREFIX(Rotate)(float Angle, hmm_vec3 Axis);
 
 COVERAGE(HMM_Scale, 1)
-HMM_INLINE hmm_mat4 HMM_Scale(hmm_vec3 Scale)
+HMM_INLINE hmm_mat4 HMM_PREFIX(Scale)(hmm_vec3 Scale)
 {
     ASSERT_COVERED(HMM_Scale);
 
-    hmm_mat4 Result = HMM_Mat4d(1.0f);
+    hmm_mat4 Result = HMM_PREFIX(Mat4d)(1.0f);
 
     Result.Elements[0][0] = Scale.X;
     Result.Elements[1][1] = Scale.Y;
@@ -1452,7 +1456,7 @@ HMM_INLINE hmm_mat4 HMM_Scale(hmm_vec3 Scale)
     return (Result);
 }
 
-HMM_EXTERN hmm_mat4 HMM_LookAt(hmm_vec3 Eye, hmm_vec3 Center, hmm_vec3 Up);
+HMM_EXTERN hmm_mat4 HMM_PREFIX(LookAt)(hmm_vec3 Eye, hmm_vec3 Center, hmm_vec3 Up);
 
 
 /*
@@ -1460,7 +1464,7 @@ HMM_EXTERN hmm_mat4 HMM_LookAt(hmm_vec3 Eye, hmm_vec3 Center, hmm_vec3 Up);
  */
 
 COVERAGE(HMM_Quaternion, 1)
-HMM_INLINE hmm_quaternion HMM_Quaternion(float X, float Y, float Z, float W)
+HMM_INLINE hmm_quaternion HMM_PREFIX(Quaternion)(float X, float Y, float Z, float W)
 {
     ASSERT_COVERED(HMM_Quaternion);
 
@@ -1479,7 +1483,7 @@ HMM_INLINE hmm_quaternion HMM_Quaternion(float X, float Y, float Z, float W)
 }
 
 COVERAGE(HMM_QuaternionV4, 1)
-HMM_INLINE hmm_quaternion HMM_QuaternionV4(hmm_vec4 Vector)
+HMM_INLINE hmm_quaternion HMM_PREFIX(QuaternionV4)(hmm_vec4 Vector)
 {
     ASSERT_COVERED(HMM_QuaternionV4);
 
@@ -1498,7 +1502,7 @@ HMM_INLINE hmm_quaternion HMM_QuaternionV4(hmm_vec4 Vector)
 }
 
 COVERAGE(HMM_AddQuaternion, 1)
-HMM_INLINE hmm_quaternion HMM_AddQuaternion(hmm_quaternion Left, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion HMM_PREFIX(AddQuaternion)(hmm_quaternion Left, hmm_quaternion Right)
 {
     ASSERT_COVERED(HMM_AddQuaternion);
 
@@ -1518,7 +1522,7 @@ HMM_INLINE hmm_quaternion HMM_AddQuaternion(hmm_quaternion Left, hmm_quaternion 
 }
 
 COVERAGE(HMM_SubtractQuaternion, 1)
-HMM_INLINE hmm_quaternion HMM_SubtractQuaternion(hmm_quaternion Left, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion HMM_PREFIX(SubtractQuaternion)(hmm_quaternion Left, hmm_quaternion Right)
 {
     ASSERT_COVERED(HMM_SubtractQuaternion);
 
@@ -1538,7 +1542,7 @@ HMM_INLINE hmm_quaternion HMM_SubtractQuaternion(hmm_quaternion Left, hmm_quater
 }
 
 COVERAGE(HMM_MultiplyQuaternion, 1)
-HMM_INLINE hmm_quaternion HMM_MultiplyQuaternion(hmm_quaternion Left, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion HMM_PREFIX(MultiplyQuaternion)(hmm_quaternion Left, hmm_quaternion Right)
 {
     ASSERT_COVERED(HMM_MultiplyQuaternion);
 
@@ -1571,7 +1575,7 @@ HMM_INLINE hmm_quaternion HMM_MultiplyQuaternion(hmm_quaternion Left, hmm_quater
 }
 
 COVERAGE(HMM_MultiplyQuaternionF, 1)
-HMM_INLINE hmm_quaternion HMM_MultiplyQuaternionF(hmm_quaternion Left, float Multiplicative)
+HMM_INLINE hmm_quaternion HMM_PREFIX(MultiplyQuaternionF)(hmm_quaternion Left, float Multiplicative)
 {
     ASSERT_COVERED(HMM_MultiplyQuaternionF);
 
@@ -1591,7 +1595,7 @@ HMM_INLINE hmm_quaternion HMM_MultiplyQuaternionF(hmm_quaternion Left, float Mul
 }
 
 COVERAGE(HMM_DivideQuaternionF, 1)
-HMM_INLINE hmm_quaternion HMM_DivideQuaternionF(hmm_quaternion Left, float Dividend)
+HMM_INLINE hmm_quaternion HMM_PREFIX(DivideQuaternionF)(hmm_quaternion Left, float Dividend)
 {
     ASSERT_COVERED(HMM_DivideQuaternionF);
 
@@ -1610,10 +1614,10 @@ HMM_INLINE hmm_quaternion HMM_DivideQuaternionF(hmm_quaternion Left, float Divid
     return (Result);
 }
 
-HMM_EXTERN hmm_quaternion HMM_InverseQuaternion(hmm_quaternion Left);
+HMM_EXTERN hmm_quaternion HMM_PREFIX(InverseQuaternion)(hmm_quaternion Left);
 
 COVERAGE(HMM_DotQuaternion, 1)
-HMM_INLINE float HMM_DotQuaternion(hmm_quaternion Left, hmm_quaternion Right)
+HMM_INLINE float HMM_PREFIX(DotQuaternion)(hmm_quaternion Left, hmm_quaternion Right)
 {
     ASSERT_COVERED(HMM_DotQuaternion);
 
@@ -1634,20 +1638,20 @@ HMM_INLINE float HMM_DotQuaternion(hmm_quaternion Left, hmm_quaternion Right)
 }
 
 COVERAGE(HMM_NormalizeQuaternion, 1)
-HMM_INLINE hmm_quaternion HMM_NormalizeQuaternion(hmm_quaternion Left)
+HMM_INLINE hmm_quaternion HMM_PREFIX(NormalizeQuaternion)(hmm_quaternion Left)
 {
     ASSERT_COVERED(HMM_NormalizeQuaternion);
 
     hmm_quaternion Result;
 
-    float Length = HMM_SquareRootF(HMM_DotQuaternion(Left, Left));
-    Result = HMM_DivideQuaternionF(Left, Length);
+    float Length = HMM_PREFIX(SquareRootF)(HMM_PREFIX(DotQuaternion)(Left, Left));
+    Result = HMM_PREFIX(DivideQuaternionF)(Left, Length);
 
     return (Result);
 }
 
 COVERAGE(HMM_NLerp, 1)
-HMM_INLINE hmm_quaternion HMM_NLerp(hmm_quaternion Left, float Time, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion HMM_PREFIX(NLerp)(hmm_quaternion Left, float Time, hmm_quaternion Right)
 {
     ASSERT_COVERED(HMM_NLerp);
 
@@ -1660,20 +1664,20 @@ HMM_INLINE hmm_quaternion HMM_NLerp(hmm_quaternion Left, float Time, hmm_quatern
     __m128 SSEResultTwo = _mm_mul_ps(Right.InternalElementsSSE, ScalarRight);
     Result.InternalElementsSSE = _mm_add_ps(SSEResultOne, SSEResultTwo);
 #else
-    Result.X = HMM_Lerp(Left.X, Time, Right.X);
-    Result.Y = HMM_Lerp(Left.Y, Time, Right.Y);
-    Result.Z = HMM_Lerp(Left.Z, Time, Right.Z);
-    Result.W = HMM_Lerp(Left.W, Time, Right.W);
+    Result.X = HMM_PREFIX(Lerp)(Left.X, Time, Right.X);
+    Result.Y = HMM_PREFIX(Lerp)(Left.Y, Time, Right.Y);
+    Result.Z = HMM_PREFIX(Lerp)(Left.Z, Time, Right.Z);
+    Result.W = HMM_PREFIX(Lerp)(Left.W, Time, Right.W);
 #endif
-    Result = HMM_NormalizeQuaternion(Result);
+    Result = HMM_PREFIX(NormalizeQuaternion)(Result);
 
     return (Result);
 }
 
-HMM_EXTERN hmm_quaternion HMM_Slerp(hmm_quaternion Left, float Time, hmm_quaternion Right);
-HMM_EXTERN hmm_mat4 HMM_QuaternionToMat4(hmm_quaternion Left);
-HMM_EXTERN hmm_quaternion HMM_Mat4ToQuaternion(hmm_mat4 Left);
-HMM_EXTERN hmm_quaternion HMM_QuaternionFromAxisAngle(hmm_vec3 Axis, float AngleOfRotation);
+HMM_EXTERN hmm_quaternion HMM_PREFIX(Slerp)(hmm_quaternion Left, float Time, hmm_quaternion Right);
+HMM_EXTERN hmm_mat4 HMM_PREFIX(QuaternionToMat4)(hmm_quaternion Left);
+HMM_EXTERN hmm_quaternion HMM_PREFIX(Mat4ToQuaternion)(hmm_mat4 Left);
+HMM_EXTERN hmm_quaternion HMM_PREFIX(QuaternionFromAxisAngle)(hmm_vec3 Axis, float AngleOfRotation);
 
 #ifdef __cplusplus
 }
@@ -1682,491 +1686,491 @@ HMM_EXTERN hmm_quaternion HMM_QuaternionFromAxisAngle(hmm_vec3 Axis, float Angle
 #ifdef __cplusplus
 
 COVERAGE(HMM_LengthVec2CPP, 1)
-HMM_INLINE float HMM_Length(hmm_vec2 A)
+HMM_INLINE float HMM_PREFIX(Length)(hmm_vec2 A)
 {
     ASSERT_COVERED(HMM_LengthVec2CPP);
 
-    float Result = HMM_LengthVec2(A);
+    float Result = HMM_PREFIX(LengthVec2)(A);
 
     return (Result);
 }
 
 COVERAGE(HMM_LengthVec3CPP, 1)
-HMM_INLINE float HMM_Length(hmm_vec3 A)
+HMM_INLINE float HMM_PREFIX(Length)(hmm_vec3 A)
 {
     ASSERT_COVERED(HMM_LengthVec3CPP);
 
-    float Result = HMM_LengthVec3(A);
+    float Result = HMM_PREFIX(LengthVec3)(A);
 
     return (Result);
 }
 
 COVERAGE(HMM_LengthVec4CPP, 1)
-HMM_INLINE float HMM_Length(hmm_vec4 A)
+HMM_INLINE float HMM_PREFIX(Length)(hmm_vec4 A)
 {
     ASSERT_COVERED(HMM_LengthVec4CPP);
 
-    float Result = HMM_LengthVec4(A);
+    float Result = HMM_PREFIX(LengthVec4)(A);
 
     return (Result);
 }
 
 COVERAGE(HMM_LengthSquaredVec2CPP, 1)
-HMM_INLINE float HMM_LengthSquared(hmm_vec2 A)
+HMM_INLINE float HMM_PREFIX(LengthSquared)(hmm_vec2 A)
 {
     ASSERT_COVERED(HMM_LengthSquaredVec2CPP);
 
-    float Result = HMM_LengthSquaredVec2(A);
+    float Result = HMM_PREFIX(LengthSquaredVec2)(A);
 
     return (Result);
 }
 
 COVERAGE(HMM_LengthSquaredVec3CPP, 1)
-HMM_INLINE float HMM_LengthSquared(hmm_vec3 A)
+HMM_INLINE float HMM_PREFIX(LengthSquared)(hmm_vec3 A)
 {
     ASSERT_COVERED(HMM_LengthSquaredVec3CPP);
 
-    float Result = HMM_LengthSquaredVec3(A);
+    float Result = HMM_PREFIX(LengthSquaredVec3)(A);
 
     return (Result);
 }
 
 COVERAGE(HMM_LengthSquaredVec4CPP, 1)
-HMM_INLINE float HMM_LengthSquared(hmm_vec4 A)
+HMM_INLINE float HMM_PREFIX(LengthSquared)(hmm_vec4 A)
 {
     ASSERT_COVERED(HMM_LengthSquaredVec4CPP);
 
-    float Result = HMM_LengthSquaredVec4(A);
+    float Result = HMM_PREFIX(LengthSquaredVec4)(A);
 
     return (Result);
 }
 
 COVERAGE(HMM_NormalizeVec2CPP, 1)
-HMM_INLINE hmm_vec2 HMM_Normalize(hmm_vec2 A)
+HMM_INLINE hmm_vec2 HMM_PREFIX(Normalize)(hmm_vec2 A)
 {
     ASSERT_COVERED(HMM_NormalizeVec2CPP);
 
-    hmm_vec2 Result = HMM_NormalizeVec2(A);
+    hmm_vec2 Result = HMM_PREFIX(NormalizeVec2)(A);
 
     return (Result);
 }
 
 COVERAGE(HMM_NormalizeVec3CPP, 1)
-HMM_INLINE hmm_vec3 HMM_Normalize(hmm_vec3 A)
+HMM_INLINE hmm_vec3 HMM_PREFIX(Normalize)(hmm_vec3 A)
 {
     ASSERT_COVERED(HMM_NormalizeVec3CPP);
 
-    hmm_vec3 Result = HMM_NormalizeVec3(A);
+    hmm_vec3 Result = HMM_PREFIX(NormalizeVec3)(A);
 
     return (Result);
 }
 
 COVERAGE(HMM_NormalizeVec4CPP, 1)
-HMM_INLINE hmm_vec4 HMM_Normalize(hmm_vec4 A)
+HMM_INLINE hmm_vec4 HMM_PREFIX(Normalize)(hmm_vec4 A)
 {
     ASSERT_COVERED(HMM_NormalizeVec4CPP);
 
-    hmm_vec4 Result = HMM_NormalizeVec4(A);
+    hmm_vec4 Result = HMM_PREFIX(NormalizeVec4)(A);
 
     return (Result);
 }
 
 COVERAGE(HMM_FastNormalizeVec2CPP, 1)
-HMM_INLINE hmm_vec2 HMM_FastNormalize(hmm_vec2 A)
+HMM_INLINE hmm_vec2 HMM_PREFIX(FastNormalize)(hmm_vec2 A)
 {
     ASSERT_COVERED(HMM_FastNormalizeVec2CPP);
 
-    hmm_vec2 Result = HMM_FastNormalizeVec2(A);
+    hmm_vec2 Result = HMM_PREFIX(FastNormalizeVec2)(A);
 
     return (Result);
 }
 
 COVERAGE(HMM_FastNormalizeVec3CPP, 1)
-HMM_INLINE hmm_vec3 HMM_FastNormalize(hmm_vec3 A)
+HMM_INLINE hmm_vec3 HMM_PREFIX(FastNormalize)(hmm_vec3 A)
 {
     ASSERT_COVERED(HMM_FastNormalizeVec3CPP);
 
-    hmm_vec3 Result = HMM_FastNormalizeVec3(A);
+    hmm_vec3 Result = HMM_PREFIX(FastNormalizeVec3)(A);
 
     return (Result);
 }
 
 COVERAGE(HMM_FastNormalizeVec4CPP, 1)
-HMM_INLINE hmm_vec4 HMM_FastNormalize(hmm_vec4 A)
+HMM_INLINE hmm_vec4 HMM_PREFIX(FastNormalize)(hmm_vec4 A)
 {
     ASSERT_COVERED(HMM_FastNormalizeVec4CPP);
 
-    hmm_vec4 Result = HMM_FastNormalizeVec4(A);
+    hmm_vec4 Result = HMM_PREFIX(FastNormalizeVec4)(A);
 
     return (Result);
 }
 
 COVERAGE(HMM_NormalizeQuaternionCPP, 1)
-HMM_INLINE hmm_quaternion HMM_Normalize(hmm_quaternion A)
+HMM_INLINE hmm_quaternion HMM_PREFIX(Normalize)(hmm_quaternion A)
 {
     ASSERT_COVERED(HMM_NormalizeQuaternionCPP);
 
-    hmm_quaternion Result = HMM_NormalizeQuaternion(A);
+    hmm_quaternion Result = HMM_PREFIX(NormalizeQuaternion)(A);
 
     return (Result);
 }
 
 COVERAGE(HMM_DotVec2CPP, 1)
-HMM_INLINE float HMM_Dot(hmm_vec2 VecOne, hmm_vec2 VecTwo)
+HMM_INLINE float HMM_PREFIX(Dot)(hmm_vec2 VecOne, hmm_vec2 VecTwo)
 {
     ASSERT_COVERED(HMM_DotVec2CPP);
 
-    float Result = HMM_DotVec2(VecOne, VecTwo);
+    float Result = HMM_PREFIX(DotVec2)(VecOne, VecTwo);
 
     return (Result);
 }
 
 COVERAGE(HMM_DotVec3CPP, 1)
-HMM_INLINE float HMM_Dot(hmm_vec3 VecOne, hmm_vec3 VecTwo)
+HMM_INLINE float HMM_PREFIX(Dot)(hmm_vec3 VecOne, hmm_vec3 VecTwo)
 {
     ASSERT_COVERED(HMM_DotVec3CPP);
 
-    float Result = HMM_DotVec3(VecOne, VecTwo);
+    float Result = HMM_PREFIX(DotVec3)(VecOne, VecTwo);
 
     return (Result);
 }
 
 COVERAGE(HMM_DotVec4CPP, 1)
-HMM_INLINE float HMM_Dot(hmm_vec4 VecOne, hmm_vec4 VecTwo)
+HMM_INLINE float HMM_PREFIX(Dot)(hmm_vec4 VecOne, hmm_vec4 VecTwo)
 {
     ASSERT_COVERED(HMM_DotVec4CPP);
 
-    float Result = HMM_DotVec4(VecOne, VecTwo);
+    float Result = HMM_PREFIX(DotVec4)(VecOne, VecTwo);
 
     return (Result);
 }
 
 COVERAGE(HMM_DotQuaternionCPP, 1)
-HMM_INLINE float HMM_Dot(hmm_quaternion QuatOne, hmm_quaternion QuatTwo)
+HMM_INLINE float HMM_PREFIX(Dot)(hmm_quaternion QuatOne, hmm_quaternion QuatTwo)
 {
     ASSERT_COVERED(HMM_DotQuaternionCPP);
 
-    float Result = HMM_DotQuaternion(QuatOne, QuatTwo);
+    float Result = HMM_PREFIX(DotQuaternion)(QuatOne, QuatTwo);
 
     return (Result);
 }
 
 COVERAGE(HMM_AddVec2CPP, 1)
-HMM_INLINE hmm_vec2 HMM_Add(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 HMM_PREFIX(Add)(hmm_vec2 Left, hmm_vec2 Right)
 {
     ASSERT_COVERED(HMM_AddVec2CPP);
 
-    hmm_vec2 Result = HMM_AddVec2(Left, Right);
+    hmm_vec2 Result = HMM_PREFIX(AddVec2)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_AddVec3CPP, 1)
-HMM_INLINE hmm_vec3 HMM_Add(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 HMM_PREFIX(Add)(hmm_vec3 Left, hmm_vec3 Right)
 {
     ASSERT_COVERED(HMM_AddVec3CPP);
 
-    hmm_vec3 Result = HMM_AddVec3(Left, Right);
+    hmm_vec3 Result = HMM_PREFIX(AddVec3)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_AddVec4CPP, 1)
-HMM_INLINE hmm_vec4 HMM_Add(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 HMM_PREFIX(Add)(hmm_vec4 Left, hmm_vec4 Right)
 {
     ASSERT_COVERED(HMM_AddVec4CPP);
 
-    hmm_vec4 Result = HMM_AddVec4(Left, Right);
+    hmm_vec4 Result = HMM_PREFIX(AddVec4)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_AddMat4CPP, 1)
-HMM_INLINE hmm_mat4 HMM_Add(hmm_mat4 Left, hmm_mat4 Right)
+HMM_INLINE hmm_mat4 HMM_PREFIX(Add)(hmm_mat4 Left, hmm_mat4 Right)
 {
     ASSERT_COVERED(HMM_AddMat4CPP);
 
-    hmm_mat4 Result = HMM_AddMat4(Left, Right);
+    hmm_mat4 Result = HMM_PREFIX(AddMat4)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_AddQuaternionCPP, 1)
-HMM_INLINE hmm_quaternion HMM_Add(hmm_quaternion Left, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion HMM_PREFIX(Add)(hmm_quaternion Left, hmm_quaternion Right)
 {
     ASSERT_COVERED(HMM_AddQuaternionCPP);
 
-    hmm_quaternion Result = HMM_AddQuaternion(Left, Right);
+    hmm_quaternion Result = HMM_PREFIX(AddQuaternion)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_SubtractVec2CPP, 1)
-HMM_INLINE hmm_vec2 HMM_Subtract(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 HMM_PREFIX(Subtract)(hmm_vec2 Left, hmm_vec2 Right)
 {
     ASSERT_COVERED(HMM_SubtractVec2CPP);
 
-    hmm_vec2 Result = HMM_SubtractVec2(Left, Right);
+    hmm_vec2 Result = HMM_PREFIX(SubtractVec2)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_SubtractVec3CPP, 1)
-HMM_INLINE hmm_vec3 HMM_Subtract(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 HMM_PREFIX(Subtract)(hmm_vec3 Left, hmm_vec3 Right)
 {
     ASSERT_COVERED(HMM_SubtractVec3CPP);
 
-    hmm_vec3 Result = HMM_SubtractVec3(Left, Right);
+    hmm_vec3 Result = HMM_PREFIX(SubtractVec3)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_SubtractVec4CPP, 1)
-HMM_INLINE hmm_vec4 HMM_Subtract(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 HMM_PREFIX(Subtract)(hmm_vec4 Left, hmm_vec4 Right)
 {
     ASSERT_COVERED(HMM_SubtractVec4CPP);
 
-    hmm_vec4 Result = HMM_SubtractVec4(Left, Right);
+    hmm_vec4 Result = HMM_PREFIX(SubtractVec4)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_SubtractMat4CPP, 1)
-HMM_INLINE hmm_mat4 HMM_Subtract(hmm_mat4 Left, hmm_mat4 Right)
+HMM_INLINE hmm_mat4 HMM_PREFIX(Subtract)(hmm_mat4 Left, hmm_mat4 Right)
 {
     ASSERT_COVERED(HMM_SubtractMat4CPP);
 
-    hmm_mat4 Result = HMM_SubtractMat4(Left, Right);
+    hmm_mat4 Result = HMM_PREFIX(SubtractMat4)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_SubtractQuaternionCPP, 1)
-HMM_INLINE hmm_quaternion HMM_Subtract(hmm_quaternion Left, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion HMM_PREFIX(Subtract)(hmm_quaternion Left, hmm_quaternion Right)
 {
     ASSERT_COVERED(HMM_SubtractQuaternionCPP);
 
-    hmm_quaternion Result = HMM_SubtractQuaternion(Left, Right);
+    hmm_quaternion Result = HMM_PREFIX(SubtractQuaternion)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_MultiplyVec2CPP, 1)
-HMM_INLINE hmm_vec2 HMM_Multiply(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 HMM_PREFIX(Multiply)(hmm_vec2 Left, hmm_vec2 Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec2CPP);
 
-    hmm_vec2 Result = HMM_MultiplyVec2(Left, Right);
+    hmm_vec2 Result = HMM_PREFIX(MultiplyVec2)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_MultiplyVec2fCPP, 1)
-HMM_INLINE hmm_vec2 HMM_Multiply(hmm_vec2 Left, float Right)
+HMM_INLINE hmm_vec2 HMM_PREFIX(Multiply)(hmm_vec2 Left, float Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec2fCPP);
 
-    hmm_vec2 Result = HMM_MultiplyVec2f(Left, Right);
+    hmm_vec2 Result = HMM_PREFIX(MultiplyVec2f)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_MultiplyVec3CPP, 1)
-HMM_INLINE hmm_vec3 HMM_Multiply(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 HMM_PREFIX(Multiply)(hmm_vec3 Left, hmm_vec3 Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec3CPP);
 
-    hmm_vec3 Result = HMM_MultiplyVec3(Left, Right);
+    hmm_vec3 Result = HMM_PREFIX(MultiplyVec3)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_MultiplyVec3fCPP, 1)
-HMM_INLINE hmm_vec3 HMM_Multiply(hmm_vec3 Left, float Right)
+HMM_INLINE hmm_vec3 HMM_PREFIX(Multiply)(hmm_vec3 Left, float Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec3fCPP);
 
-    hmm_vec3 Result = HMM_MultiplyVec3f(Left, Right);
+    hmm_vec3 Result = HMM_PREFIX(MultiplyVec3f)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_MultiplyVec4CPP, 1)
-HMM_INLINE hmm_vec4 HMM_Multiply(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 HMM_PREFIX(Multiply)(hmm_vec4 Left, hmm_vec4 Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec4CPP);
 
-    hmm_vec4 Result = HMM_MultiplyVec4(Left, Right);
+    hmm_vec4 Result = HMM_PREFIX(MultiplyVec4)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_MultiplyVec4fCPP, 1)
-HMM_INLINE hmm_vec4 HMM_Multiply(hmm_vec4 Left, float Right)
+HMM_INLINE hmm_vec4 HMM_PREFIX(Multiply)(hmm_vec4 Left, float Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec4fCPP);
 
-    hmm_vec4 Result = HMM_MultiplyVec4f(Left, Right);
+    hmm_vec4 Result = HMM_PREFIX(MultiplyVec4f)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_MultiplyMat4CPP, 1)
-HMM_INLINE hmm_mat4 HMM_Multiply(hmm_mat4 Left, hmm_mat4 Right)
+HMM_INLINE hmm_mat4 HMM_PREFIX(Multiply)(hmm_mat4 Left, hmm_mat4 Right)
 {
     ASSERT_COVERED(HMM_MultiplyMat4CPP);
 
-    hmm_mat4 Result = HMM_MultiplyMat4(Left, Right);
+    hmm_mat4 Result = HMM_PREFIX(MultiplyMat4)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_MultiplyMat4fCPP, 1)
-HMM_INLINE hmm_mat4 HMM_Multiply(hmm_mat4 Left, float Right)
+HMM_INLINE hmm_mat4 HMM_PREFIX(Multiply)(hmm_mat4 Left, float Right)
 {
     ASSERT_COVERED(HMM_MultiplyMat4fCPP);
 
-    hmm_mat4 Result = HMM_MultiplyMat4f(Left, Right);
+    hmm_mat4 Result = HMM_PREFIX(MultiplyMat4f)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_MultiplyMat4ByVec4CPP, 1)
-HMM_INLINE hmm_vec4 HMM_Multiply(hmm_mat4 Matrix, hmm_vec4 Vector)
+HMM_INLINE hmm_vec4 HMM_PREFIX(Multiply)(hmm_mat4 Matrix, hmm_vec4 Vector)
 {
     ASSERT_COVERED(HMM_MultiplyMat4ByVec4CPP);
 
-    hmm_vec4 Result = HMM_MultiplyMat4ByVec4(Matrix, Vector);
+    hmm_vec4 Result = HMM_PREFIX(MultiplyMat4ByVec4)(Matrix, Vector);
 
     return (Result);
 }
 
 COVERAGE(HMM_MultiplyQuaternionCPP, 1)
-HMM_INLINE hmm_quaternion HMM_Multiply(hmm_quaternion Left, hmm_quaternion Right)
+HMM_INLINE hmm_quaternion HMM_PREFIX(Multiply)(hmm_quaternion Left, hmm_quaternion Right)
 {
     ASSERT_COVERED(HMM_MultiplyQuaternionCPP);
 
-    hmm_quaternion Result = HMM_MultiplyQuaternion(Left, Right);
+    hmm_quaternion Result = HMM_PREFIX(MultiplyQuaternion)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_MultiplyQuaternionFCPP, 1)
-HMM_INLINE hmm_quaternion HMM_Multiply(hmm_quaternion Left, float Right)
+HMM_INLINE hmm_quaternion HMM_PREFIX(Multiply)(hmm_quaternion Left, float Right)
 {
     ASSERT_COVERED(HMM_MultiplyQuaternionFCPP);
 
-    hmm_quaternion Result = HMM_MultiplyQuaternionF(Left, Right);
+    hmm_quaternion Result = HMM_PREFIX(MultiplyQuaternionF)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_DivideVec2CPP, 1)
-HMM_INLINE hmm_vec2 HMM_Divide(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_vec2 HMM_PREFIX(Divide)(hmm_vec2 Left, hmm_vec2 Right)
 {
     ASSERT_COVERED(HMM_DivideVec2CPP);
 
-    hmm_vec2 Result = HMM_DivideVec2(Left, Right);
+    hmm_vec2 Result = HMM_PREFIX(DivideVec2)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_DivideVec2fCPP, 1)
-HMM_INLINE hmm_vec2 HMM_Divide(hmm_vec2 Left, float Right)
+HMM_INLINE hmm_vec2 HMM_PREFIX(Divide)(hmm_vec2 Left, float Right)
 {
     ASSERT_COVERED(HMM_DivideVec2fCPP);
 
-    hmm_vec2 Result = HMM_DivideVec2f(Left, Right);
+    hmm_vec2 Result = HMM_PREFIX(DivideVec2f)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_DivideVec3CPP, 1)
-HMM_INLINE hmm_vec3 HMM_Divide(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_vec3 HMM_PREFIX(Divide)(hmm_vec3 Left, hmm_vec3 Right)
 {
     ASSERT_COVERED(HMM_DivideVec3CPP);
 
-    hmm_vec3 Result = HMM_DivideVec3(Left, Right);
+    hmm_vec3 Result = HMM_PREFIX(DivideVec3)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_DivideVec3fCPP, 1)
-HMM_INLINE hmm_vec3 HMM_Divide(hmm_vec3 Left, float Right)
+HMM_INLINE hmm_vec3 HMM_PREFIX(Divide)(hmm_vec3 Left, float Right)
 {
     ASSERT_COVERED(HMM_DivideVec3fCPP);
 
-    hmm_vec3 Result = HMM_DivideVec3f(Left, Right);
+    hmm_vec3 Result = HMM_PREFIX(DivideVec3f)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_DivideVec4CPP, 1)
-HMM_INLINE hmm_vec4 HMM_Divide(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_vec4 HMM_PREFIX(Divide)(hmm_vec4 Left, hmm_vec4 Right)
 {
     ASSERT_COVERED(HMM_DivideVec4CPP);
 
-    hmm_vec4 Result = HMM_DivideVec4(Left, Right);
+    hmm_vec4 Result = HMM_PREFIX(DivideVec4)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_DivideVec4fCPP, 1)
-HMM_INLINE hmm_vec4 HMM_Divide(hmm_vec4 Left, float Right)
+HMM_INLINE hmm_vec4 HMM_PREFIX(Divide)(hmm_vec4 Left, float Right)
 {
     ASSERT_COVERED(HMM_DivideVec4fCPP);
 
-    hmm_vec4 Result = HMM_DivideVec4f(Left, Right);
+    hmm_vec4 Result = HMM_PREFIX(DivideVec4f)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_DivideMat4fCPP, 1)
-HMM_INLINE hmm_mat4 HMM_Divide(hmm_mat4 Left, float Right)
+HMM_INLINE hmm_mat4 HMM_PREFIX(Divide)(hmm_mat4 Left, float Right)
 {
     ASSERT_COVERED(HMM_DivideMat4fCPP);
 
-    hmm_mat4 Result = HMM_DivideMat4f(Left, Right);
+    hmm_mat4 Result = HMM_PREFIX(DivideMat4f)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_DivideQuaternionFCPP, 1)
-HMM_INLINE hmm_quaternion HMM_Divide(hmm_quaternion Left, float Right)
+HMM_INLINE hmm_quaternion HMM_PREFIX(Divide)(hmm_quaternion Left, float Right)
 {
     ASSERT_COVERED(HMM_DivideQuaternionFCPP);
 
-    hmm_quaternion Result = HMM_DivideQuaternionF(Left, Right);
+    hmm_quaternion Result = HMM_PREFIX(DivideQuaternionF)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_EqualsVec2CPP, 1)
-HMM_INLINE hmm_bool HMM_Equals(hmm_vec2 Left, hmm_vec2 Right)
+HMM_INLINE hmm_bool HMM_PREFIX(Equals)(hmm_vec2 Left, hmm_vec2 Right)
 {
     ASSERT_COVERED(HMM_EqualsVec2CPP);
 
-    hmm_bool Result = HMM_EqualsVec2(Left, Right);
+    hmm_bool Result = HMM_PREFIX(EqualsVec2)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_EqualsVec3CPP, 1)
-HMM_INLINE hmm_bool HMM_Equals(hmm_vec3 Left, hmm_vec3 Right)
+HMM_INLINE hmm_bool HMM_PREFIX(Equals)(hmm_vec3 Left, hmm_vec3 Right)
 {
     ASSERT_COVERED(HMM_EqualsVec3CPP);
 
-    hmm_bool Result = HMM_EqualsVec3(Left, Right);
+    hmm_bool Result = HMM_PREFIX(EqualsVec3)(Left, Right);
 
     return (Result);
 }
 
 COVERAGE(HMM_EqualsVec4CPP, 1)
-HMM_INLINE hmm_bool HMM_Equals(hmm_vec4 Left, hmm_vec4 Right)
+HMM_INLINE hmm_bool HMM_PREFIX(Equals)(hmm_vec4 Left, hmm_vec4 Right)
 {
     ASSERT_COVERED(HMM_EqualsVec4CPP);
 
-    hmm_bool Result = HMM_EqualsVec4(Left, Right);
+    hmm_bool Result = HMM_PREFIX(EqualsVec4)(Left, Right);
 
     return (Result);
 }
@@ -2176,7 +2180,7 @@ HMM_INLINE hmm_vec2 operator+(hmm_vec2 Left, hmm_vec2 Right)
 {
     ASSERT_COVERED(HMM_AddVec2Op);
 
-    hmm_vec2 Result = HMM_AddVec2(Left, Right);
+    hmm_vec2 Result = HMM_PREFIX(AddVec2)(Left, Right);
 
     return (Result);
 }
@@ -2186,7 +2190,7 @@ HMM_INLINE hmm_vec3 operator+(hmm_vec3 Left, hmm_vec3 Right)
 {
     ASSERT_COVERED(HMM_AddVec3Op);
 
-    hmm_vec3 Result = HMM_AddVec3(Left, Right);
+    hmm_vec3 Result = HMM_PREFIX(AddVec3)(Left, Right);
 
     return (Result);
 }
@@ -2196,7 +2200,7 @@ HMM_INLINE hmm_vec4 operator+(hmm_vec4 Left, hmm_vec4 Right)
 {
     ASSERT_COVERED(HMM_AddVec4Op);
 
-    hmm_vec4 Result = HMM_AddVec4(Left, Right);
+    hmm_vec4 Result = HMM_PREFIX(AddVec4)(Left, Right);
 
     return (Result);
 }
@@ -2206,7 +2210,7 @@ HMM_INLINE hmm_mat4 operator+(hmm_mat4 Left, hmm_mat4 Right)
 {
     ASSERT_COVERED(HMM_AddMat4Op);
 
-    hmm_mat4 Result = HMM_AddMat4(Left, Right);
+    hmm_mat4 Result = HMM_PREFIX(AddMat4)(Left, Right);
 
     return (Result);
 }
@@ -2216,7 +2220,7 @@ HMM_INLINE hmm_quaternion operator+(hmm_quaternion Left, hmm_quaternion Right)
 {
     ASSERT_COVERED(HMM_AddQuaternionOp);
 
-    hmm_quaternion Result = HMM_AddQuaternion(Left, Right);
+    hmm_quaternion Result = HMM_PREFIX(AddQuaternion)(Left, Right);
 
     return (Result);
 }
@@ -2226,7 +2230,7 @@ HMM_INLINE hmm_vec2 operator-(hmm_vec2 Left, hmm_vec2 Right)
 {
     ASSERT_COVERED(HMM_SubtractVec2Op);
 
-    hmm_vec2 Result = HMM_SubtractVec2(Left, Right);
+    hmm_vec2 Result = HMM_PREFIX(SubtractVec2)(Left, Right);
 
     return (Result);
 }
@@ -2236,7 +2240,7 @@ HMM_INLINE hmm_vec3 operator-(hmm_vec3 Left, hmm_vec3 Right)
 {
     ASSERT_COVERED(HMM_SubtractVec3Op);
 
-    hmm_vec3 Result = HMM_SubtractVec3(Left, Right);
+    hmm_vec3 Result = HMM_PREFIX(SubtractVec3)(Left, Right);
 
     return (Result);
 }
@@ -2246,7 +2250,7 @@ HMM_INLINE hmm_vec4 operator-(hmm_vec4 Left, hmm_vec4 Right)
 {
     ASSERT_COVERED(HMM_SubtractVec4Op);
 
-    hmm_vec4 Result = HMM_SubtractVec4(Left, Right);
+    hmm_vec4 Result = HMM_PREFIX(SubtractVec4)(Left, Right);
 
     return (Result);
 }
@@ -2256,7 +2260,7 @@ HMM_INLINE hmm_mat4 operator-(hmm_mat4 Left, hmm_mat4 Right)
 {
     ASSERT_COVERED(HMM_SubtractMat4Op);
 
-    hmm_mat4 Result = HMM_SubtractMat4(Left, Right);
+    hmm_mat4 Result = HMM_PREFIX(SubtractMat4)(Left, Right);
 
     return (Result);
 }
@@ -2266,7 +2270,7 @@ HMM_INLINE hmm_quaternion operator-(hmm_quaternion Left, hmm_quaternion Right)
 {
     ASSERT_COVERED(HMM_SubtractQuaternionOp);
 
-    hmm_quaternion Result = HMM_SubtractQuaternion(Left, Right);
+    hmm_quaternion Result = HMM_PREFIX(SubtractQuaternion)(Left, Right);
 
     return (Result);
 }
@@ -2276,7 +2280,7 @@ HMM_INLINE hmm_vec2 operator*(hmm_vec2 Left, hmm_vec2 Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec2Op);
 
-    hmm_vec2 Result = HMM_MultiplyVec2(Left, Right);
+    hmm_vec2 Result = HMM_PREFIX(MultiplyVec2)(Left, Right);
 
     return (Result);
 }
@@ -2286,7 +2290,7 @@ HMM_INLINE hmm_vec3 operator*(hmm_vec3 Left, hmm_vec3 Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec3Op);
 
-    hmm_vec3 Result = HMM_MultiplyVec3(Left, Right);
+    hmm_vec3 Result = HMM_PREFIX(MultiplyVec3)(Left, Right);
 
     return (Result);
 }
@@ -2296,7 +2300,7 @@ HMM_INLINE hmm_vec4 operator*(hmm_vec4 Left, hmm_vec4 Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec4Op);
 
-    hmm_vec4 Result = HMM_MultiplyVec4(Left, Right);
+    hmm_vec4 Result = HMM_PREFIX(MultiplyVec4)(Left, Right);
 
     return (Result);
 }
@@ -2306,7 +2310,7 @@ HMM_INLINE hmm_mat4 operator*(hmm_mat4 Left, hmm_mat4 Right)
 {
     ASSERT_COVERED(HMM_MultiplyMat4Op);
 
-    hmm_mat4 Result = HMM_MultiplyMat4(Left, Right);
+    hmm_mat4 Result = HMM_PREFIX(MultiplyMat4)(Left, Right);
 
     return (Result);
 }
@@ -2316,7 +2320,7 @@ HMM_INLINE hmm_quaternion operator*(hmm_quaternion Left, hmm_quaternion Right)
 {
     ASSERT_COVERED(HMM_MultiplyQuaternionOp);
 
-    hmm_quaternion Result = HMM_MultiplyQuaternion(Left, Right);
+    hmm_quaternion Result = HMM_PREFIX(MultiplyQuaternion)(Left, Right);
 
     return (Result);
 }
@@ -2326,7 +2330,7 @@ HMM_INLINE hmm_vec2 operator*(hmm_vec2 Left, float Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec2fOp);
 
-    hmm_vec2 Result = HMM_MultiplyVec2f(Left, Right);
+    hmm_vec2 Result = HMM_PREFIX(MultiplyVec2f)(Left, Right);
 
     return (Result);
 }
@@ -2336,7 +2340,7 @@ HMM_INLINE hmm_vec3 operator*(hmm_vec3 Left, float Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec3fOp);
 
-    hmm_vec3 Result = HMM_MultiplyVec3f(Left, Right);
+    hmm_vec3 Result = HMM_PREFIX(MultiplyVec3f)(Left, Right);
 
     return (Result);
 }
@@ -2346,7 +2350,7 @@ HMM_INLINE hmm_vec4 operator*(hmm_vec4 Left, float Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec4fOp);
 
-    hmm_vec4 Result = HMM_MultiplyVec4f(Left, Right);
+    hmm_vec4 Result = HMM_PREFIX(MultiplyVec4f)(Left, Right);
 
     return (Result);
 }
@@ -2356,7 +2360,7 @@ HMM_INLINE hmm_mat4 operator*(hmm_mat4 Left, float Right)
 {
     ASSERT_COVERED(HMM_MultiplyMat4fOp);
 
-    hmm_mat4 Result = HMM_MultiplyMat4f(Left, Right);
+    hmm_mat4 Result = HMM_PREFIX(MultiplyMat4f)(Left, Right);
 
     return (Result);
 }
@@ -2366,7 +2370,7 @@ HMM_INLINE hmm_quaternion operator*(hmm_quaternion Left, float Right)
 {
     ASSERT_COVERED(HMM_MultiplyQuaternionFOp);
 
-    hmm_quaternion Result = HMM_MultiplyQuaternionF(Left, Right);
+    hmm_quaternion Result = HMM_PREFIX(MultiplyQuaternionF)(Left, Right);
 
     return (Result);
 }
@@ -2376,7 +2380,7 @@ HMM_INLINE hmm_vec2 operator*(float Left, hmm_vec2 Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec2fOpLeft);
 
-    hmm_vec2 Result = HMM_MultiplyVec2f(Right, Left);
+    hmm_vec2 Result = HMM_PREFIX(MultiplyVec2f)(Right, Left);
 
     return (Result);
 }
@@ -2386,7 +2390,7 @@ HMM_INLINE hmm_vec3 operator*(float Left, hmm_vec3 Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec3fOpLeft);
 
-    hmm_vec3 Result = HMM_MultiplyVec3f(Right, Left);
+    hmm_vec3 Result = HMM_PREFIX(MultiplyVec3f)(Right, Left);
 
     return (Result);
 }
@@ -2396,7 +2400,7 @@ HMM_INLINE hmm_vec4 operator*(float Left, hmm_vec4 Right)
 {
     ASSERT_COVERED(HMM_MultiplyVec4fOpLeft);
 
-    hmm_vec4 Result = HMM_MultiplyVec4f(Right, Left);
+    hmm_vec4 Result = HMM_PREFIX(MultiplyVec4f)(Right, Left);
 
     return (Result);
 }
@@ -2406,7 +2410,7 @@ HMM_INLINE hmm_mat4 operator*(float Left, hmm_mat4 Right)
 {
     ASSERT_COVERED(HMM_MultiplyMat4fOpLeft);
 
-    hmm_mat4 Result = HMM_MultiplyMat4f(Right, Left);
+    hmm_mat4 Result = HMM_PREFIX(MultiplyMat4f)(Right, Left);
 
     return (Result);
 }
@@ -2416,7 +2420,7 @@ HMM_INLINE hmm_quaternion operator*(float Left, hmm_quaternion Right)
 {
     ASSERT_COVERED(HMM_MultiplyQuaternionFOpLeft);
 
-    hmm_quaternion Result = HMM_MultiplyQuaternionF(Right, Left);
+    hmm_quaternion Result = HMM_PREFIX(MultiplyQuaternionF)(Right, Left);
 
     return (Result);
 }
@@ -2426,7 +2430,7 @@ HMM_INLINE hmm_vec4 operator*(hmm_mat4 Matrix, hmm_vec4 Vector)
 {
     ASSERT_COVERED(HMM_MultiplyMat4ByVec4Op);
 
-    hmm_vec4 Result = HMM_MultiplyMat4ByVec4(Matrix, Vector);
+    hmm_vec4 Result = HMM_PREFIX(MultiplyMat4ByVec4)(Matrix, Vector);
 
     return (Result);
 }
@@ -2436,7 +2440,7 @@ HMM_INLINE hmm_vec2 operator/(hmm_vec2 Left, hmm_vec2 Right)
 {
     ASSERT_COVERED(HMM_DivideVec2Op);
 
-    hmm_vec2 Result = HMM_DivideVec2(Left, Right);
+    hmm_vec2 Result = HMM_PREFIX(DivideVec2)(Left, Right);
 
     return (Result);
 }
@@ -2446,7 +2450,7 @@ HMM_INLINE hmm_vec3 operator/(hmm_vec3 Left, hmm_vec3 Right)
 {
     ASSERT_COVERED(HMM_DivideVec3Op);
 
-    hmm_vec3 Result = HMM_DivideVec3(Left, Right);
+    hmm_vec3 Result = HMM_PREFIX(DivideVec3)(Left, Right);
 
     return (Result);
 }
@@ -2456,7 +2460,7 @@ HMM_INLINE hmm_vec4 operator/(hmm_vec4 Left, hmm_vec4 Right)
 {
     ASSERT_COVERED(HMM_DivideVec4Op);
 
-    hmm_vec4 Result = HMM_DivideVec4(Left, Right);
+    hmm_vec4 Result = HMM_PREFIX(DivideVec4)(Left, Right);
 
     return (Result);
 }
@@ -2466,7 +2470,7 @@ HMM_INLINE hmm_vec2 operator/(hmm_vec2 Left, float Right)
 {
     ASSERT_COVERED(HMM_DivideVec2fOp);
 
-    hmm_vec2 Result = HMM_DivideVec2f(Left, Right);
+    hmm_vec2 Result = HMM_PREFIX(DivideVec2f)(Left, Right);
 
     return (Result);
 }
@@ -2476,7 +2480,7 @@ HMM_INLINE hmm_vec3 operator/(hmm_vec3 Left, float Right)
 {
     ASSERT_COVERED(HMM_DivideVec3fOp);
 
-    hmm_vec3 Result = HMM_DivideVec3f(Left, Right);
+    hmm_vec3 Result = HMM_PREFIX(DivideVec3f)(Left, Right);
 
     return (Result);
 }
@@ -2486,7 +2490,7 @@ HMM_INLINE hmm_vec4 operator/(hmm_vec4 Left, float Right)
 {
     ASSERT_COVERED(HMM_DivideVec4fOp);
 
-    hmm_vec4 Result = HMM_DivideVec4f(Left, Right);
+    hmm_vec4 Result = HMM_PREFIX(DivideVec4f)(Left, Right);
 
     return (Result);
 }
@@ -2496,7 +2500,7 @@ HMM_INLINE hmm_mat4 operator/(hmm_mat4 Left, float Right)
 {
     ASSERT_COVERED(HMM_DivideMat4fOp);
 
-    hmm_mat4 Result = HMM_DivideMat4f(Left, Right);
+    hmm_mat4 Result = HMM_PREFIX(DivideMat4f)(Left, Right);
 
     return (Result);
 }
@@ -2506,7 +2510,7 @@ HMM_INLINE hmm_quaternion operator/(hmm_quaternion Left, float Right)
 {
     ASSERT_COVERED(HMM_DivideQuaternionFOp);
 
-    hmm_quaternion Result = HMM_DivideQuaternionF(Left, Right);
+    hmm_quaternion Result = HMM_PREFIX(DivideQuaternionF)(Left, Right);
 
     return (Result);
 }
@@ -2724,7 +2728,7 @@ HMM_INLINE hmm_bool operator==(hmm_vec2 Left, hmm_vec2 Right)
 {
     ASSERT_COVERED(HMM_EqualsVec2Op);
 
-    return HMM_EqualsVec2(Left, Right);
+    return HMM_PREFIX(EqualsVec2)(Left, Right);
 }
 
 COVERAGE(HMM_EqualsVec3Op, 1)
@@ -2732,7 +2736,7 @@ HMM_INLINE hmm_bool operator==(hmm_vec3 Left, hmm_vec3 Right)
 {
     ASSERT_COVERED(HMM_EqualsVec3Op);
 
-    return HMM_EqualsVec3(Left, Right);
+    return HMM_PREFIX(EqualsVec3)(Left, Right);
 }
 
 COVERAGE(HMM_EqualsVec4Op, 1)
@@ -2740,7 +2744,7 @@ HMM_INLINE hmm_bool operator==(hmm_vec4 Left, hmm_vec4 Right)
 {
     ASSERT_COVERED(HMM_EqualsVec4Op);
 
-    return HMM_EqualsVec4(Left, Right);
+    return HMM_PREFIX(EqualsVec4)(Left, Right);
 }
 
 COVERAGE(HMM_EqualsVec2OpNot, 1)
@@ -2748,7 +2752,7 @@ HMM_INLINE hmm_bool operator!=(hmm_vec2 Left, hmm_vec2 Right)
 {
     ASSERT_COVERED(HMM_EqualsVec2OpNot);
 
-    return !HMM_EqualsVec2(Left, Right);
+    return !HMM_PREFIX(EqualsVec2)(Left, Right);
 }
 
 COVERAGE(HMM_EqualsVec3OpNot, 1)
@@ -2756,7 +2760,7 @@ HMM_INLINE hmm_bool operator!=(hmm_vec3 Left, hmm_vec3 Right)
 {
     ASSERT_COVERED(HMM_EqualsVec3OpNot);
 
-    return !HMM_EqualsVec3(Left, Right);
+    return !HMM_PREFIX(EqualsVec3)(Left, Right);
 }
 
 COVERAGE(HMM_EqualsVec4OpNot, 1)
@@ -2764,7 +2768,7 @@ HMM_INLINE hmm_bool operator!=(hmm_vec4 Left, hmm_vec4 Right)
 {
     ASSERT_COVERED(HMM_EqualsVec4OpNot);
 
-    return !HMM_EqualsVec4(Left, Right);
+    return !HMM_PREFIX(EqualsVec4)(Left, Right);
 }
 
 #endif /* __cplusplus */
@@ -2879,10 +2883,10 @@ hmm_mat4 HMM_MultiplyMat4(hmm_mat4 Left, hmm_mat4 Right)
     hmm_mat4 Result;
 
 #ifdef HANDMADE_MATH__USE_SSE
-    Result.Columns[0] = HMM_LinearCombineSSE(Right.Columns[0], Left);
-    Result.Columns[1] = HMM_LinearCombineSSE(Right.Columns[1], Left);
-    Result.Columns[2] = HMM_LinearCombineSSE(Right.Columns[2], Left);
-    Result.Columns[3] = HMM_LinearCombineSSE(Right.Columns[3], Left);
+    Result.Columns[0] = HMM_PREFIX(LinearCombineSSE)(Right.Columns[0], Left);
+    Result.Columns[1] = HMM_PREFIX(LinearCombineSSE)(Right.Columns[1], Left);
+    Result.Columns[2] = HMM_PREFIX(LinearCombineSSE)(Right.Columns[2], Left);
+    Result.Columns[3] = HMM_PREFIX(LinearCombineSSE)(Right.Columns[3], Left);
 #else
     int Columns;
     for(Columns = 0; Columns < 4; ++Columns)
@@ -2935,7 +2939,7 @@ hmm_vec4 HMM_MultiplyMat4ByVec4(hmm_mat4 Matrix, hmm_vec4 Vector)
     hmm_vec4 Result;
 
 #ifdef HANDMADE_MATH__USE_SSE
-	Result.InternalElementsSSE = HMM_LinearCombineSSE(Vector.InternalElementsSSE, Matrix);
+	Result.InternalElementsSSE = HMM_PREFIX(LinearCombineSSE)(Vector.InternalElementsSSE, Matrix);
 #else
     int Columns, Rows;
     for(Rows = 0; Rows < 4; ++Rows)
@@ -2984,8 +2988,8 @@ hmm_mat4 HMM_Rotate(float Angle, hmm_vec3 Axis)
 
     Axis = HMM_NormalizeVec3(Axis);
 
-    float SinTheta = HMM_SinF(HMM_ToRadians(Angle));
-    float CosTheta = HMM_CosF(HMM_ToRadians(Angle));
+    float SinTheta = HMM_PREFIX(SinF)(HMM_PREFIX(ToRadians)(Angle));
+    float CosTheta = HMM_PREFIX(CosF)(HMM_PREFIX(ToRadians)(Angle));
     float CosValue = 1.0f - CosTheta;
 
     Result.Elements[0][0] = (Axis.X * Axis.X * CosValue) + CosTheta;
@@ -3010,9 +3014,9 @@ hmm_mat4 HMM_LookAt(hmm_vec3 Eye, hmm_vec3 Center, hmm_vec3 Up)
 
     hmm_mat4 Result;
 
-    hmm_vec3 F = HMM_NormalizeVec3(HMM_SubtractVec3(Center, Eye));
-    hmm_vec3 S = HMM_NormalizeVec3(HMM_Cross(F, Up));
-    hmm_vec3 U = HMM_Cross(S, F);
+    hmm_vec3 F = HMM_PREFIX(NormalizeVec3)(HMM_PREFIX(SubtractVec3)(Center, Eye));
+    hmm_vec3 S = HMM_PREFIX(NormalizeVec3)(HMM_PREFIX(Cross)(F, Up));
+    hmm_vec3 U = HMM_PREFIX(Cross)(S, F);
 
     Result.Elements[0][0] = S.X;
     Result.Elements[0][1] = U.X;
@@ -3029,9 +3033,9 @@ hmm_mat4 HMM_LookAt(hmm_vec3 Eye, hmm_vec3 Center, hmm_vec3 Up)
     Result.Elements[2][2] = -F.Z;
     Result.Elements[2][3] = 0.0f;
 
-    Result.Elements[3][0] = -HMM_DotVec3(S, Eye);
-    Result.Elements[3][1] = -HMM_DotVec3(U, Eye);
-    Result.Elements[3][2] = HMM_DotVec3(F, Eye);
+    Result.Elements[3][0] = -HMM_PREFIX(DotVec3)(S, Eye);
+    Result.Elements[3][1] = -HMM_PREFIX(DotVec3)(U, Eye);
+    Result.Elements[3][2] = HMM_PREFIX(DotVec3)(F, Eye);
     Result.Elements[3][3] = 1.0f;
 
     return (Result);
@@ -3052,10 +3056,10 @@ hmm_quaternion HMM_InverseQuaternion(hmm_quaternion Left)
     Conjugate.Z = -Left.Z;
     Conjugate.W = Left.W;
 
-    Norm = HMM_SquareRootF(HMM_DotQuaternion(Left, Left));
+    Norm = HMM_PREFIX(SquareRootF)(HMM_PREFIX(DotQuaternion)(Left, Left));
     NormSquared = Norm * Norm;
 
-    Result = HMM_DivideQuaternionF(Conjugate, NormSquared);
+    Result = HMM_PREFIX(DivideQuaternionF)(Conjugate, NormSquared);
 
     return (Result);
 }
@@ -3069,18 +3073,18 @@ hmm_quaternion HMM_Slerp(hmm_quaternion Left, float Time, hmm_quaternion Right)
     hmm_quaternion QuaternionLeft;
     hmm_quaternion QuaternionRight;
 
-    float Cos_Theta = HMM_DotQuaternion(Left, Right);
-    float Angle = HMM_ACosF(Cos_Theta);
+    float Cos_Theta = HMM_PREFIX(DotQuaternion)(Left, Right);
+    float Angle = HMM_PREFIX(ACosF)(Cos_Theta);
 
-    float S1 = HMM_SinF((1.0f - Time) * Angle);
-    float S2 = HMM_SinF(Time * Angle);
-    float Is = 1.0f / HMM_SinF(Angle);
+    float S1 = HMM_PREFIX(SinF)((1.0f - Time) * Angle);
+    float S2 = HMM_PREFIX(SinF)(Time * Angle);
+    float Is = 1.0f / HMM_PREFIX(SinF)(Angle);
 
-    QuaternionLeft = HMM_MultiplyQuaternionF(Left, S1);
-    QuaternionRight = HMM_MultiplyQuaternionF(Right, S2);
+    QuaternionLeft = HMM_PREFIX(MultiplyQuaternionF)(Left, S1);
+    QuaternionRight = HMM_PREFIX(MultiplyQuaternionF)(Right, S2);
 
-    Result = HMM_AddQuaternion(QuaternionLeft, QuaternionRight);
-    Result = HMM_MultiplyQuaternionF(Result, Is);
+    Result = HMM_PREFIX(AddQuaternion)(QuaternionLeft, QuaternionRight);
+    Result = HMM_PREFIX(MultiplyQuaternionF)(Result, Is);
 
     return (Result);
 }
@@ -3092,7 +3096,7 @@ hmm_mat4 HMM_QuaternionToMat4(hmm_quaternion Left)
 
     hmm_mat4 Result;
 
-    hmm_quaternion NormalizedQuaternion = HMM_NormalizeQuaternion(Left);
+    hmm_quaternion NormalizedQuaternion = HMM_PREFIX(NormalizeQuaternion)(Left);
 
     float XX, YY, ZZ,
           XY, XZ, YZ,
@@ -3156,7 +3160,7 @@ hmm_quaternion HMM_Mat4ToQuaternion(hmm_mat4 M)
             ASSERT_COVERED(HMM_Mat4ToQuaternion);
 
             T = 1 + M.Elements[0][0] - M.Elements[1][1] - M.Elements[2][2];
-            Q = HMM_Quaternion(
+            Q = HMM_PREFIX(Quaternion)(
                 T,
                 M.Elements[0][1] + M.Elements[1][0],
                 M.Elements[2][0] + M.Elements[0][2],
@@ -3166,7 +3170,7 @@ hmm_quaternion HMM_Mat4ToQuaternion(hmm_mat4 M)
             ASSERT_COVERED(HMM_Mat4ToQuaternion);
 
             T = 1 - M.Elements[0][0] + M.Elements[1][1] - M.Elements[2][2];
-            Q = HMM_Quaternion(
+            Q = HMM_PREFIX(Quaternion)(
                 M.Elements[0][1] + M.Elements[1][0],
                 T,
                 M.Elements[1][2] + M.Elements[2][1],
@@ -3178,7 +3182,7 @@ hmm_quaternion HMM_Mat4ToQuaternion(hmm_mat4 M)
             ASSERT_COVERED(HMM_Mat4ToQuaternion);
 
             T = 1 - M.Elements[0][0] - M.Elements[1][1] + M.Elements[2][2];
-            Q = HMM_Quaternion(
+            Q = HMM_PREFIX(Quaternion)(
                 M.Elements[2][0] + M.Elements[0][2],
                 M.Elements[1][2] + M.Elements[2][1],
                 T,
@@ -3188,7 +3192,7 @@ hmm_quaternion HMM_Mat4ToQuaternion(hmm_mat4 M)
             ASSERT_COVERED(HMM_Mat4ToQuaternion);
 
             T = 1 + M.Elements[0][0] + M.Elements[1][1] + M.Elements[2][2];
-            Q = HMM_Quaternion(
+            Q = HMM_PREFIX(Quaternion)(
                 M.Elements[1][2] - M.Elements[2][1],
                 M.Elements[2][0] - M.Elements[0][2],
                 M.Elements[0][1] - M.Elements[1][0],
@@ -3197,7 +3201,7 @@ hmm_quaternion HMM_Mat4ToQuaternion(hmm_mat4 M)
         }
     }
 
-    Q = HMM_MultiplyQuaternionF(Q, 0.5f / HMM_SquareRootF(T));
+    Q = HMM_PREFIX(MultiplyQuaternionF)(Q, 0.5f / HMM_PREFIX(SquareRootF)(T));
 
     return Q;
 }
@@ -3209,11 +3213,11 @@ hmm_quaternion HMM_QuaternionFromAxisAngle(hmm_vec3 Axis, float AngleOfRotation)
 
     hmm_quaternion Result;
 
-    hmm_vec3 AxisNormalized = HMM_NormalizeVec3(Axis);
-    float SineOfRotation = HMM_SinF(AngleOfRotation / 2.0f);
+    hmm_vec3 AxisNormalized = HMM_PREFIX(NormalizeVec3)(Axis);
+    float SineOfRotation = HMM_PREFIX(SinF)(AngleOfRotation / 2.0f);
 
-    Result.XYZ = HMM_MultiplyVec3f(AxisNormalized, SineOfRotation);
-    Result.W = HMM_CosF(AngleOfRotation / 2.0f);
+    Result.XYZ = HMM_PREFIX(MultiplyVec3f)(AxisNormalized, SineOfRotation);
+    Result.W = HMM_PREFIX(CosF)(AngleOfRotation / 2.0f);
 
     return (Result);
 }

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -2984,9 +2984,9 @@ hmm_mat4 HMM_Rotate(float Angle, hmm_vec3 Axis)
 {
     ASSERT_COVERED(HMM_Rotate);
 
-    hmm_mat4 Result = HMM_Mat4d(1.0f);
+    hmm_mat4 Result = HMM_PREFIX(Mat4d)(1.0f);
 
-    Axis = HMM_NormalizeVec3(Axis);
+    Axis = HMM_PREFIX(NormalizeVec3)(Axis);
 
     float SinTheta = HMM_PREFIX(SinF)(HMM_PREFIX(ToRadians)(Angle));
     float CosTheta = HMM_PREFIX(CosF)(HMM_PREFIX(ToRadians)(Angle));

--- a/test/HandmadeMathDifferentPrefix.cpp
+++ b/test/HandmadeMathDifferentPrefix.cpp
@@ -1,0 +1,12 @@
+#define HMM_PREFIX(name) WOW_##name
+
+#define HANDMADE_MATH_IMPLEMENTATION
+#define HANDMADE_MATH_NO_INLINE
+#include "../HandmadeMath.h"
+
+int main() {
+    hmm_vec4 a = WOW_Vec4(1, 2, 3, 4);
+    hmm_vec4 b = WOW_Vec4(5, 6, 7, 8);
+
+    WOW_Add(a, b);
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,7 +2,7 @@ BUILD_DIR=./build
 
 CXXFLAGS+=-g -Wall -Wextra -pthread -Wno-missing-braces -Wno-missing-field-initializers
 
-all: c c_no_sse cpp cpp_no_sse build_c_without_coverage build_cpp_without_coverage
+all: c c_no_sse cpp cpp_no_sse build_c_without_coverage build_cpp_without_coverage build_cpp_different_prefix
 
 build_all: build_c build_c_no_sse build_cpp build_cpp_no_sse
 
@@ -58,7 +58,7 @@ build_cpp_no_sse: HandmadeMath.cpp test_impl
 
 test_impl: hmm_test.cpp hmm_test.c
 
-build_c_without_coverage: HandmadeMath.c
+build_c_without_coverage: HandmadeMath.c test_impl
 	@echo "\nCompiling in C mode"
 	mkdir -p $(BUILD_DIR)
 	cd $(BUILD_DIR)\
@@ -75,3 +75,11 @@ build_cpp_without_coverage: HandmadeMath.cpp test_impl
 		&& $(CXX) $(CPPFLAGS) $(CXXFLAGS) -ohmm_test_cpp_no_sse \
 			-DHANDMADE_MATH_CPP_MODE -DWITHOUT_COVERAGE \
 			../HandmadeMath.cpp ../hmm_test.cpp
+
+build_cpp_different_prefix: HandmadeMath.cpp
+	@echo "\nCompiling C++ with different prefix"
+	mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) \
+		&& $(CXX) $(CPPFLAGS) $(CXXFLAGS) -ohmm_test_cpp_different_prefix \
+			-DHANDMADE_MATH_CPP_MODE -DDIFFERENT_PREFIX \
+			../HandmadeMathDifferentPrefix.cpp


### PR DESCRIPTION
Resolves #112. I only did this to function names; types have a lowercase prefix and can be easily `typedef`'d anyway.