### PR TITLE
Make HMM_Clamp branchless in optimized builds

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -595,7 +595,8 @@ HMM_INLINE float HMM_PREFIX(Clamp)(float Min, float Value, float Max)
     {
         Result = Min;
     }
-    else if(Result > Max)
+
+    if(Result > Max)
     {
         Result = Max;
     }


### PR DESCRIPTION
See #121. While looking into the performance of that patch, I found that you can make the function branchless and get similar performance gains just by breaking the if / else if into two ifs.

The reason is because this is the generated ASM for the current version:

```asm
        comiss  xmm0, xmm1
        ja      .L2
        minss   xmm2, xmm1
        movaps  xmm0, xmm2
.L2:
        ret
```

And this is what is generated for this new version:

```asm
        maxss   xmm0, xmm1
        minss   xmm2, xmm0
        movaps  xmm0, xmm2
        ret
```

In [my tests](https://github.com/HandmadeMath/Handmade-Math/pull/121#issuecomment-740068640), I found that this version performed the best in both optimized _and_ unoptimized builds.

Godbolt: https://godbolt.org/z/n93q9E
Benchmark: https://quick-bench.com/q/JvCK6K9Jk9omAFZ2d9WNuj9YXZw

Let's see if this works:
Closes #121 