### PR TITLE
Add brackets around HMM_MIN, HMM_MAX, and HMM_MOD

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -220,7 +220,7 @@ extern "C"
 #define HMM_MIN(a, b) ((a) > (b) ? (b) : (a))
 #define HMM_MAX(a, b) ((a) < (b) ? (b) : (a))
 #define HMM_ABS(a) ((a) > 0 ? (a) : -(a))
-#define HMM_MOD(a, m) ((a) % (m)) >= 0 ? ((a) % (m)) : (((a) % (m)) + (m))
+#define HMM_MOD(a, m) (((a) % (m)) >= 0 ? ((a) % (m)) : (((a) % (m)) + (m)))
 #define HMM_SQUARE(x) ((x) * (x))
 
 #ifndef HMM_PREFIX

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -217,8 +217,8 @@ extern "C"
 #define HMM_PI32 3.14159265359f
 #define HMM_PI 3.14159265358979323846
 
-#define HMM_MIN(a, b) (a) > (b) ? (b) : (a)
-#define HMM_MAX(a, b) (a) < (b) ? (b) : (a)
+#define HMM_MIN(a, b) ((a) > (b) ? (b) : (a))
+#define HMM_MAX(a, b) ((a) < (b) ? (b) : (a))
 #define HMM_ABS(a) ((a) > 0 ? (a) : -(a))
 #define HMM_MOD(a, m) ((a) % (m)) >= 0 ? ((a) % (m)) : (((a) % (m)) + (m))
 #define HMM_SQUARE(x) ((x) * (x))


### PR DESCRIPTION
I ran into an issue with operator precedence weirdness with the HMM_MIN and HMM_MAX macros. So I added brackets around them to solve those issues.