### PR TITLE
docs: fix simple typo, percision -> precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Version         | Changes        |
 **0.5**     | Added scalar operations on vectors and matrices, added += and -= for hmm_mat4, reconciled headers and implementations, tidied up in general |
 **0.4**     | Added SSE Optimized HMM_SqrtF, HMM_RSqrtF, Removed use of C Runtime | 
 **0.3**     | Added +=,-=, *=, /= for hmm_vec2, hmm_vec3, hmm_vec4 | 
-**0.2b**    | Disabled warning C4201 on MSVC, Added 64bit percision on HMM_PI | 
+**0.2b**    | Disabled warning C4201 on MSVC, Added 64bit precision on HMM_PI | 
 **0.2a**    | Prefixed Macros | 
 **0.2**     | Updated Documentation, Fixed C Compliance, Prefixed all functions, and added better operator overloading | 
 **0.1**     | Initial Version | 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `precision` rather than `percision`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md