### PR TITLE
Suppress two warnings on clang 12

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -143,11 +143,12 @@
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
-#if defined(__GNUC__) && (__GNUC__ == 4 && __GNUC_MINOR__ < 8)
+#if (defined(__GNUC__) && (__GNUC__ == 4 && __GNUC_MINOR__ < 8)) || defined(__clang__)
 #pragma GCC diagnostic ignored "-Wmissing-braces"
 #endif
 #ifdef __clang__
 #pragma GCC diagnostic ignored "-Wgnu-anonymous-struct"
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 #endif
 


### PR DESCRIPTION
Building with clang 12 with -Wextra, the following two warnings are
generated:

```
HandmadeMath.h:1167:25: warning: missing field 'Y' initializer [-Wmissing-field-initializers]
    hmm_vec2 Result = {0};
                        ^
HandmadeMath.h:1167:24: warning: suggest braces around initialization of subobject [-Wmissing-braces]
```

This expands the `-Wmissing-braces` ignore to also target clang, and adds an
ignore for `-Wmissing-field-initializers`