### PR TITLE
fix warnings

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -2332,7 +2332,7 @@ static inline HMM_Quat HMM_NormQ(HMM_Quat Quat)
     /* NOTE(lcf): Take advantage of SSE implementation in HMM_NormV4 */
     HMM_Vec4 Vec = HMM_V4(Quat.X, Quat.Y, Quat.Z, Quat.W);
     Vec = HMM_NormV4(Vec);
-    HMM_Quat Result = HMM_Q(Vec.X, Vec.Y, Vec.Z, Vec.W);
+    HMM_Quat Result = HMM_QV4(Vec);
 
     return Result;
 }

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -2329,9 +2329,9 @@ static inline HMM_Quat HMM_NormQ(HMM_Quat Quat)
     ASSERT_COVERED(HMM_NormQ);
 
     /* NOTE(lcf): Take advantage of SSE implementation in HMM_NormV4 */
-    HMM_Vec4 Vec = {Quat.X, Quat.Y, Quat.Z, Quat.W};
+    HMM_Vec4 Vec = HMM_V4(Quat.X, Quat.Y, Quat.Z, Quat.W);
     Vec = HMM_NormV4(Vec);
-    HMM_Quat Result = {Vec.X, Vec.Y, Vec.Z, Vec.W};
+    HMM_Quat Result = HMM_Q(Vec.X, Vec.Y, Vec.Z, Vec.W);
 
     return Result;
 }
@@ -3804,7 +3804,7 @@ static inline HMM_Vec4 operator-(HMM_Vec4 In)
 
 #ifdef HANDMADE_MATH__USE_C11_GENERICS
 
-void __hmm_invalid_generic();
+void __hmm_invalid_generic(void);
 
 #define HMM_Add(A, B) _Generic((A), \
     HMM_Vec2: HMM_AddV2, \

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -256,7 +256,7 @@ typedef union HMM_Vec2
 
 #ifdef __cplusplus
     inline float &operator[](int Index) { return Elements[Index]; }
-    inline const float& operator[](int Index) const { return Elements[Index]; }
+    inline const float &operator[](int Index) const { return Elements[Index]; }
 #endif
 } HMM_Vec2;
 

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -150,6 +150,7 @@
 # pragma GCC diagnostic ignored "-Wmissing-braces"
 # ifdef __clang__
 #  pragma GCC diagnostic ignored "-Wgnu-anonymous-struct"
+#  pragma GCC diagnostic ignored "-Wnested-anon-types"
 #  pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 # endif
 #endif


### PR DESCRIPTION
compiles C11 without warnings when the warning pragmas are removed
adds clang++ pedantic warning